### PR TITLE
Configure FPP locs search paths and select from locs found in project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+.DS_Store
 
 src/grammar/venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.8] - 2024-06-12
 
-- Added ability to configure search paths for FPP locs and select from locs found in project
+- Configure FPP locs search paths and select from locs found in project
 
 ## [1.0.7] - 2024-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.0.8] - 2024-06-12
+
+- Added ability to configure search paths for FPP locs and select from locs found in project
 
 ## [1.0.7] - 2024-03-18
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/fprime-community/vscode-fpp",
         "type": "git"
     },
-    "version": "1.0.7",
+    "version": "1.0.8",
     "icon": "fprime-logo.png",
     "engines": {
         "vscode": "^1.78.0"
@@ -26,6 +26,10 @@
             {
                 "command": "fpp.reload",
                 "title": "FPP: Reload Project"
+            },
+            {
+                "command": "fpp.select",
+                "title": "FPP: Select Locs file inside workspace"
             },
             {
                 "command": "fpp.close",
@@ -68,6 +72,27 @@
                     "name": "FPP Components"
                 }
             ]
+        },
+        "configuration": {
+            "title": "FPP",
+            "type": "object",
+            "properties": {
+                "fpp.locsSearch": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "markdownDescription": "Glob patterns in order of priority to search for an `locs.fpp` on project startup if no other locs is selected",
+                    "default": [
+                        "**/build-fprime-automatic-native/locs.fpp",
+                        "**/build-fprime-*/locs.fpp"
+                    ]
+                },
+                "fpp.locsExclude": {
+                    "type": "string",
+                    "markdownDescription": "Glob pattern path to exclude from `locs.fpp` search"
+                }
+            }
         }
     },
     "scripts": {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -376,7 +376,6 @@ export function getCandidates(
                 parser
             };
         } else {
-            console.log(e);
             throw e;
         }
     }

--- a/src/decl.ts
+++ b/src/decl.ts
@@ -481,9 +481,6 @@ export class DeclCollector extends MemberTraverser {
 
     generalPortInstanceDecl(ast: Fpp.GeneralPortInstanceDecl, scope: Fpp.QualifiedIdentifier): void {
         const portName = MemberTraverser.flat(scope, ast.name);
-        if (ast.name.value === 'send') {
-            console.log(portName, ast);
-        }
 
         if (ast.kind.isOutput) {
             this.generalOutputPortDecl.set(portName, ast);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { FppParser, QualIdentContext } from './grammar/FppParser';
 
 import * as Fpp from './parser/ast';
+import * as Settings from './settings';
 
 import Signatures from "./signatures.json";
 import { CompletionRelevantInfo, getCandidates } from './completion';
@@ -26,6 +27,10 @@ interface ISignature {
         offset: number;
         map: Record<string, number[]>
     } | string[];
+}
+
+function locs(context: vscode.ExtensionContext) {
+    return context.workspaceState.get<string>("fpp.locsFile");
 }
 
 function generateSignature(signature: ISignature, activeParameter: string): vscode.SignatureInformation {
@@ -159,11 +164,26 @@ class FppExtension implements
 
         // Once the worker boots up, load the project
         this.subscriptions = [];
-        this.project.ready().then(() => {
-            const file = this.context.workspaceState.get<string>("fpp.locsFile");
+        this.project.ready().then(async () => {
+            // Check if a locs file is already selected by this workspace
+            const filePath = locs(this.context);
+            let file = filePath ? vscode.Uri.file(filePath) : undefined;
+
+            if (!file) {
+                // Attempt to glob search for locs file
+                file = await this.searchForLocs();
+            }
+
+            if (!file) {
+                vscode.window.showWarningMessage('No fpp.locs is loaded', 'Open').then((value) => {
+                    if (value === "Open") {
+                        vscode.commands.executeCommand('fpp.open');
+                    }
+                });
+            }
 
             // Don't allow the language providers interfere with the project loading
-            this.setProject(file ? vscode.Uri.file(file) : undefined)
+            this.setProject(file)
                 .finally(() => {
                     this.subscriptions = [
                         // Update the internal ast on document change
@@ -187,6 +207,46 @@ class FppExtension implements
                     ];
                 });
         });
+    }
+
+    /**
+     * Searches through the locs search paths in order to find an `fpp.locs` file
+     * @returns Promise to locs file or `undefined` if not found
+     */
+    async searchForLocs() {
+        try {
+            return await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Window,
+                title: "Searching for fpp.locs",
+                cancellable: true
+            }, async (progress, token) => {
+                const searchPaths = Settings.locsSearch();
+                const excludeGlob = Settings.excludeLocs();
+
+                for (const searchPath of searchPaths) {
+                    progress.report({
+                        message: `Searching ${searchPath}`,
+                        increment: (100 / searchPath.length)
+                    });
+
+                    const found = await vscode.workspace.findFiles(
+                        searchPath,
+                        excludeGlob,
+                        1,
+                        token
+                    );
+
+                    if (found.length > 0) {
+                        return found[0];
+                    }
+                }
+
+                return undefined;
+            });
+        }
+        catch (e) {
+            vscode.window.showWarningMessage(`Failed to find locs.fpp: ${e}`);
+        }
     }
 
     private readonly symbolTraverser = new class extends MemberTraverser {
@@ -324,7 +384,7 @@ class FppExtension implements
     }
 
     async setProject(locsFile: vscode.Uri | undefined) {
-        this.context.workspaceState.update('fpp.locsFile', locsFile?.path);
+        await this.context.workspaceState.update('fpp.locsFile', locsFile?.path);
         await this.project.set(locsFile);
     }
 
@@ -708,26 +768,99 @@ class FppExtension implements
     }
 }
 
+interface LocsQuickPickOpen extends vscode.QuickPickItem {
+    kind: vscode.QuickPickItemKind.Default;
+    isOpen: true;
+}
+
+interface LocsQuickPickFile extends vscode.QuickPickItem {
+    kind: vscode.QuickPickItemKind.Default;
+    isOpen: false;
+    uri: vscode.Uri;
+}
+
+interface LocsQuickPickSeparator extends vscode.QuickPickItem {
+    kind: vscode.QuickPickItemKind.Separator;
+}
+
+type LocsQuickPickItem = LocsQuickPickOpen | LocsQuickPickFile | LocsQuickPickSeparator;
+
 export function activate(context: vscode.ExtensionContext) {
     const extension = new FppExtension(context);
 
     context.subscriptions.push(
         extension,
         vscode.commands.registerCommand('fpp.reload', extension.reload.bind(extension)),
-        vscode.commands.registerCommand('fpp.load', async (file?: vscode.Uri) => {
+        vscode.commands.registerCommand('fpp.load', (file?: vscode.Uri) => {
             if (!file) {
-                vscode.commands.executeCommand('fpp.open');
+                return vscode.commands.executeCommand('fpp.open');
             } else {
-                await extension.setProject(file);
+                return extension.setProject(file);
             }
+        }),
+        vscode.commands.registerCommand('fpp.select', () => {
+            vscode.window.showQuickPick(
+                (async () => {
+                    const currentLocs = locs(context);
+
+                    const searchPaths = Settings.locsSearch();
+                    const excludeGlob = Settings.excludeLocs();
+
+                    const files = new Map<string, vscode.Uri>();
+                    const items: LocsQuickPickItem[] = [
+                        {
+                            kind: vscode.QuickPickItemKind.Default,
+                            label: '$(open) Open',
+                            isOpen: true
+                        },
+                        {
+                            kind: vscode.QuickPickItemKind.Separator,
+                            label: ''
+                        }
+                    ];
+
+                    for (const searchPath of searchPaths) {
+                        for (const file of await vscode.workspace.findFiles(
+                            searchPath,
+                            excludeGlob,
+                        )) {
+                            files.set(vscode.workspace.asRelativePath(file), file);
+                        }
+                    }
+
+                    for (const [relPath, uri] of files.entries()) {
+                        items.push({
+                            kind: vscode.QuickPickItemKind.Default,
+                            label: relPath,
+                            uri,
+                            isOpen: false,
+                            picked: currentLocs === relPath
+                        } as LocsQuickPickFile);
+                    }
+
+                    return items;
+                })(),
+                {
+                    title: 'Select FPP Locs for project indexing',
+                    canPickMany: false,
+                }
+            ).then((picked) => {
+                if (picked?.kind === vscode.QuickPickItemKind.Default) {
+                    if (picked.isOpen) {
+                        vscode.commands.executeCommand('fpp.open');
+                    } else {
+                        extension.setProject(picked.uri);
+                    }
+                }
+            });
         }),
         vscode.commands.registerCommand('fpp.close', async () => {
             await extension.setProject(undefined);
         }),
         vscode.commands.registerCommand('fpp.open', () => {
-            const locs = context.workspaceState.get<string>("fpp.locsFile");
+            const currentLocs = locs(context);
             vscode.window.showOpenDialog({
-                defaultUri: locs ? vscode.Uri.file(locs) : undefined,
+                defaultUri: currentLocs ? vscode.Uri.file(currentLocs) : undefined,
                 openLabel: "Open locs",
                 canSelectFiles: true,
                 canSelectFolders: false,
@@ -741,6 +874,12 @@ export function activate(context: vscode.ExtensionContext) {
                 }
             });
         }),
+        Settings.onLocsSearchChanged(() => {
+            // Don't re-scan if a locs file is already loaded
+            if (!locs(context)) {
+                extension.searchForLocs().then((f) => extension.setProject(f));
+            }
+        })
     );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -834,7 +834,7 @@ export function activate(context: vscode.ExtensionContext) {
                             label: relPath,
                             uri,
                             isOpen: false,
-                            picked: currentLocs === relPath
+                            description: currentLocs === uri.path ? '(Active)' : undefined
                         } as LocsQuickPickFile);
                     }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -9,7 +9,9 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
     private locs = new Set<string>();
     private locsFile?: vscode.Uri;
 
-    private locsNew: vscode.LanguageStatusItem;
+    private availableLocs = new Set<string>();
+
+    private locsSelect: vscode.LanguageStatusItem;
     private locsReload: vscode.LanguageStatusItem;
 
     private loadingProject: boolean = false;
@@ -17,11 +19,11 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
     constructor(selector: vscode.DocumentSelector) {
         super(selector);
 
-        this.locsNew = vscode.languages.createLanguageStatusItem(
+        this.locsSelect = vscode.languages.createLanguageStatusItem(
             'fpp.locsNew',
             this.documentSelector
         );
-        this.locsNew.name = "FPP Project Status";
+        this.locsSelect.name = "FPP Project Status";
 
         this.locsReload = vscode.languages.createLanguageStatusItem(
             'fpp.locsReload',
@@ -35,9 +37,9 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
 
     private refreshLanguageStatus() {
         if (!this.locsFile) {
-            this.locsNew.text = "No `locs.fpp` file file loaded";
-            this.locsNew.command = { title: "Load", command: "fpp.open" };
-            this.locsNew.severity = vscode.LanguageStatusSeverity.Warning;
+            this.locsSelect.text = "No `locs.fpp` file file loaded";
+            this.locsSelect.command = { title: "Select", command: "fpp.select" };
+            this.locsSelect.severity = vscode.LanguageStatusSeverity.Warning;
 
             // Don't show this language item right now
             this.locsReload.selector = { scheme: 'INVALID', language: 'INVALID' };
@@ -46,9 +48,9 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
             this.locsReload.detail = undefined;
             this.locsReload.text = "";
         } else {
-            this.locsNew.text = "FPP Project Loaded";
-            this.locsNew.command = { title: "Close", command: "fpp.close" };
-            this.locsNew.severity = vscode.LanguageStatusSeverity.Information;
+            this.locsSelect.text = "FPP Project Loaded";
+            this.locsSelect.command = { title: "Select", command: "fpp.select" };
+            this.locsSelect.severity = vscode.LanguageStatusSeverity.Information;
 
             this.locsReload.selector = this.documentSelector;
             this.locsReload.command = { title: "Reload", command: "fpp.reload" };
@@ -198,8 +200,8 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
         } catch (e) {
             console.error(e);
             vscode.window.showErrorMessage(`Failed to load locs.fpp: ${e}`);
-            this.locsNew.text = "Locs load failed";
-            this.locsNew.severity = vscode.LanguageStatusSeverity.Error;
+            this.locsSelect.text = "Locs load failed";
+            this.locsSelect.severity = vscode.LanguageStatusSeverity.Error;
         } finally {
             this.locsReload.busy = false;
         }
@@ -214,7 +216,7 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
             this.locsFile = locsFile;
 
             this.refreshLanguageStatus();
-            this.locsNew.busy = true;
+            this.locsSelect.busy = true;
 
             try {
                 await vscode.window.withProgress({
@@ -225,10 +227,10 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
             } catch (e) {
                 console.error(e);
                 vscode.window.showErrorMessage(`Failed to load locs.fpp: ${e}`);
-                this.locsNew.text = "Locs load failed";
-                this.locsNew.severity = vscode.LanguageStatusSeverity.Error;
+                this.locsSelect.text = "Locs load failed";
+                this.locsSelect.severity = vscode.LanguageStatusSeverity.Error;
             } finally {
-                this.locsNew.busy = false;
+                this.locsSelect.busy = false;
             }
         }
     }
@@ -236,7 +238,7 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
     dispose() {
         super.dispose();
         this.locs.clear();
-        this.locsNew.dispose();
+        this.locsSelect.dispose();
         this.locsReload.dispose();
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+const names = {
+    locsSearch: "fpp.locsSearch",
+    locsExclude: "fpp.locsExclude"
+};
+
+export function locsSearch(): string[] {
+    return vscode.workspace.getConfiguration().get<string[]>(names.locsSearch) ?? [
+        "**/build-fprime-automatic-native/locs.fpp",
+        "**/build-fprime-*/locs.fpp"
+    ];
+}
+
+export function excludeLocs(): string | null {
+    return vscode.workspace.getConfiguration().get<string | null>(names.locsExclude) ?? null;
+}
+
+export function onLocsSearchChanged(callback: () => void): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration(names.locsSearch)
+            || e.affectsConfiguration(names.locsExclude)
+        ) {
+            callback();
+        }
+    });
+}


### PR DESCRIPTION
New settings for searching through workspace for `locs.fpp`
<img width="1226" alt="Screenshot 2024-06-12 at 12 48 06 PM" src="https://github.com/fprime-community/vscode-fpp/assets/15131751/5e481c0a-90ec-440a-a5b2-d79c0527fff6">

Initial project opening detecting an `locs.fpp` from the search paths

https://github.com/fprime-community/vscode-fpp/assets/15131751/30bdc1b9-044d-4063-8d2d-9c0d274ff1e5

Selecting between project locs:

https://github.com/fprime-community/vscode-fpp/assets/15131751/7bbf5a0a-0958-491a-ae41-a52a7a6314c5

Closes https://github.com/nasa/fprime/issues/2776
