### PR TITLE
Fix scoping of states in state machines and add more completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.10] - 2024-06-12
 
+- Fixed scoping sematics of state machine states
+- Added completions for a couple state machine expressions
+
+## [1.0.10] - 2024-06-12
+
 - Added support for state machines
 
 ## [1.0.9] - 2024-06-12

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/fprime-community/vscode-fpp",
         "type": "git"
     },
-    "version": "1.0.10",
+    "version": "1.0.11",
     "icon": "fprime-logo.png",
     "engines": {
         "vscode": "^1.78.0"

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -12,7 +12,7 @@ import {
 } from 'antlr4ts';
 
 import { FppLexer } from './grammar/FppLexer';
-import { ComponentDeclContext, FppParser, ModuleDeclContext } from './grammar/FppParser';
+import { ComponentDeclContext, FppParser, ModuleDeclContext, StateMachineDefContext } from './grammar/FppParser';
 import { ATN, ATNConfigSet, ATNState, RuleTransition } from 'antlr4ts/atn';
 import { AbstractParseTreeVisitor } from 'antlr4ts/tree/AbstractParseTreeVisitor';
 import { FppVisitor } from './grammar/FppVisitor';
@@ -131,6 +131,13 @@ class BasicVisitor extends AbstractParseTreeVisitor<void> implements FppVisitor<
         super.visitChildren(ctx);
         this.scope = oldScope;
     }
+
+    visitStateMachineDef(ctx: StateMachineDefContext) {
+        const oldScope = this.scope;
+        this.scope = [...oldScope, ctx.IDENTIFIER().text];
+        super.visitChildren(ctx);
+        this.scope = oldScope;
+    }
 }
 
 class FppParserWrapper extends FppParser {
@@ -238,9 +245,12 @@ function getRuleMetadata(context: ParserRuleContext, state: number, relevantRule
 
     for (; relevantContext; invokingState = relevantContext.invokingState, relevantContext = relevantContext.parent) {
         if (relevantContext.ruleIndex === FppParser.RULE_moduleDecl ||
-            relevantContext.ruleIndex === FppParser.RULE_componentDecl
+            relevantContext.ruleIndex === FppParser.RULE_componentDecl ||
+            relevantContext.ruleIndex === FppParser.RULE_stateMachineDef
         ) {
-            const declName = (relevantContext as (ModuleDeclContext | ComponentDeclContext)).tryGetToken(FppParser.IDENTIFIER, 0)?.text;
+            const declName = (relevantContext as (
+                ModuleDeclContext | ComponentDeclContext | StateMachineDefContext
+            )).tryGetToken(FppParser.IDENTIFIER, 0)?.text;
             if (declName) {
                 scope.push(declName);
             } else {


### PR DESCRIPTION
This fixes some scoping issues for state/choice lookups. State/choice qual-idents are now automatically prefixed with the scope of the parent state machine. The scope of the nested states is kept separately during AST traverse so that the symbol resolution can properly resolve state qual-identifiers.

This PR also adds some state machine statement completion for guards, choices, states, signals, and actions