### PR TITLE
Allow loading FPP project from entire workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.12] - 2025-01-31
+
+- Added a second project scanning mode for loading all .fpp files in workspace
+- Cleaned up parse queuing
+- Cleaned up some issues with .fppi parenting
+- Fixed some edge case parsing errors with special ports
+
 ## [1.0.11] - 2025-01-29
 
 - Fixed scoping sematics of state machine states

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/fprime-community/vscode-fpp",
         "type": "git"
     },
-    "version": "1.0.11",
+    "version": "1.0.12",
     "icon": "fprime-logo.png",
     "engines": {
         "vscode": "^1.78.0"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
                 "title": "FPP: Select Locs file inside workspace"
             },
             {
+                "command": "fpp.useWorkspace",
+                "title": "FPP: Scan entire workspace instead of locs file"
+            },
+            {
                 "command": "fpp.close",
                 "title": "FPP: Close Project"
             },

--- a/src/locs.ts
+++ b/src/locs.ts
@@ -1,14 +1,24 @@
 import * as vscode from 'vscode';
-import * as Settings from './settings';
+
+export enum LocsQuickPickType {
+    locsOpenDialog,
+    locsFile,
+    workspaceScan
+}
 
 export interface LocsQuickPickOpen extends vscode.QuickPickItem {
     kind: vscode.QuickPickItemKind.Default;
-    isOpen: true;
+    locsKind: LocsQuickPickType.locsOpenDialog;
+}
+
+export interface LocsQuickPickWorkspaceScan extends vscode.QuickPickItem {
+    kind: vscode.QuickPickItemKind.Default;
+    locsKind: LocsQuickPickType.workspaceScan;
 }
 
 export interface LocsQuickPickFile extends vscode.QuickPickItem {
     kind: vscode.QuickPickItemKind.Default;
-    isOpen: false;
+    locsKind: LocsQuickPickType.locsFile;
     uri: vscode.Uri;
 }
 
@@ -16,7 +26,12 @@ export interface LocsQuickPickSeparator extends vscode.QuickPickItem {
     kind: vscode.QuickPickItemKind.Separator;
 }
 
-export type LocsQuickPickItem = LocsQuickPickOpen | LocsQuickPickFile | LocsQuickPickSeparator;
+export type LocsQuickPickItem = (
+    | LocsQuickPickOpen
+    | LocsQuickPickWorkspaceScan
+    | LocsQuickPickFile
+    | LocsQuickPickSeparator
+);
 
 export function locs(context: vscode.ExtensionContext) {
     return context.workspaceState.get<string>("fpp.locsFile");

--- a/src/parser/message.ts
+++ b/src/parser/message.ts
@@ -22,3 +22,9 @@ export interface IFppWorkerRequest {
     text: string;
     subText?: [string, string]
 }
+
+export type IFPPResponse = (
+    | { code: "error", msg: string }
+    | { code: "success", msg: IFppMessage }
+    | { code: "startup" }
+);

--- a/src/parser/visitor.ts
+++ b/src/parser/visitor.ts
@@ -646,7 +646,7 @@ export class AstVisitor extends AbstractParseTreeVisitor<Fpp.Ast> implements Fpp
             } else {
                 return {
                     location: this.loc(ctx),
-                    kind: this.keywordsT([commandK.symbol, recvK!.symbol], "commandRecv"),
+                    kind: this.keywordsT([commandK.symbol, recvK?.symbol].filter(v => v !== undefined), "commandRecv"),
                     isOutput: false,
                     isSpecial: true
                 };
@@ -655,16 +655,18 @@ export class AstVisitor extends AbstractParseTreeVisitor<Fpp.Ast> implements Fpp
             if (getK) {
                 kind = this.keywordsT([paramK.symbol, getK.symbol], "paramGet");
             } else {
-                kind = this.keywordsT([paramK.symbol, setK!.symbol], "paramSet");
+                kind = this.keywordsT([paramK.symbol, setK?.symbol].filter(v => v !== undefined), "paramSet");
             }
         } else if (telemetryK) {
             kind = this.keywordT<"telemetry">(telemetryK.symbol);
         } else if (textK) {
-            kind = this.keywordsT([textK.symbol, eventK!.symbol], "textEvent");
+            kind = this.keywordsT([textK.symbol, eventK?.symbol].filter(v => v !== undefined), "textEvent");
         } else if (eventK) {
             kind = this.keywordT<"event">(eventK.symbol);
+        } else if (timeK && getK) {
+            kind = this.keywordsT([timeK.symbol, getK.symbol], "timeGet");
         } else {
-            kind = this.keywordsT([timeK!.symbol, getK!.symbol], "timeGet");
+            return this.error();
         }
 
         return {

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,17 +1,14 @@
 import * as vscode from 'vscode';
 
-import * as Fpp from './parser/ast';
-import { MemberTraverser } from './traverser';
-import { symLinkCache } from './annotator';
 import { FppProjectManager } from './manager';
+import { EntireWorkspaceScanner, LocsFileScanner, WorkspaceFileScanner } from './workspace';
+import { symLinkCache } from './annotator';
 
 export class FppProject extends FppProjectManager implements vscode.Disposable {
-    private locs = new Set<string>();
-    private locsFile?: vscode.Uri;
+    private files = new Set<string>();
+    private workspace?: WorkspaceFileScanner;
 
-    private availableLocs = new Set<string>();
-
-    private locsSelect: vscode.LanguageStatusItem;
+    private projectSelect: vscode.LanguageStatusItem;
     private locsReload: vscode.LanguageStatusItem;
 
     private loadingProject: boolean = false;
@@ -19,11 +16,11 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
     constructor(selector: vscode.DocumentSelector) {
         super(selector);
 
-        this.locsSelect = vscode.languages.createLanguageStatusItem(
-            'fpp.locsNew',
+        this.projectSelect = vscode.languages.createLanguageStatusItem(
+            'fpp.project',
             this.documentSelector
         );
-        this.locsSelect.name = "FPP Project Status";
+        this.projectSelect.name = "FPP Project Status";
 
         this.locsReload = vscode.languages.createLanguageStatusItem(
             'fpp.locsReload',
@@ -31,15 +28,13 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
         );
 
         this.refreshLanguageStatus();
-
-        this.locsTrav.parent = this;
     }
 
     private refreshLanguageStatus() {
-        if (!this.locsFile) {
-            this.locsSelect.text = "No `locs.fpp` file file loaded";
-            this.locsSelect.command = { title: "Select", command: "fpp.select" };
-            this.locsSelect.severity = vscode.LanguageStatusSeverity.Warning;
+        if (!this.workspace) {
+            this.projectSelect.text = "No `locs.fpp` file or workspace loaded";
+            this.projectSelect.command = { title: "Select", command: "fpp.select" };
+            this.projectSelect.severity = vscode.LanguageStatusSeverity.Warning;
 
             // Don't show this language item right now
             this.locsReload.selector = { scheme: 'INVALID', language: 'INVALID' };
@@ -48,25 +43,25 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
             this.locsReload.detail = undefined;
             this.locsReload.text = "";
         } else {
-            this.locsSelect.text = "FPP Project Loaded";
-            this.locsSelect.command = { title: "Select", command: "fpp.select" };
-            this.locsSelect.severity = vscode.LanguageStatusSeverity.Information;
+            this.projectSelect.text = "FPP Project Loaded";
+            this.projectSelect.command = { title: "Select", command: "fpp.select" };
+            this.projectSelect.severity = vscode.LanguageStatusSeverity.Information;
 
             this.locsReload.selector = this.documentSelector;
             this.locsReload.command = { title: "Reload", command: "fpp.reload" };
             this.locsReload.detail = "Reload FPP Project";
-            this.locsReload.text = vscode.workspace.asRelativePath(this.locsFile);
+            this.locsReload.text = this.workspace.label();
         }
     }
 
     // Tracks which files should be tracked by the decl collector
     inProject(path: string): boolean {
-        const isInProject = this.loadingProject || this.locs.has(path);
+        const isInProject = this.loadingProject || this.files.has(path);
         if (!isInProject) {
             const parentFiles = this.parentFiles.get(path);
             if (parentFiles) {
                 for (const parentFile of parentFiles) {
-                    if (this.locs.has(parentFile)) {
+                    if (this.files.has(parentFile)) {
                         return true;
                     }
                 }
@@ -78,114 +73,23 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
         return isInProject;
     }
 
-    clearAll(): void {
-        this.locs.clear();
-        super.clearAll();
-    }
-
     private async scan(progress: vscode.Progress<{ message?: string; increment?: number }>, token: vscode.CancellationToken) {
-        // Read the locsFile file
-        if (!this.locsFile) {
-            throw new Error('No locs loaded');
-        }
-
-        symLinkCache.clear();
         this.clearAll();
-
-        progress.report({
-            message: "Scanning locs file",
-            increment: 0
-        });
-
-        // Parse the locs file
-        const { ast } = await this.parse(this.locsFile, undefined, {
-            forceReparse: true,
-            disableAnnotations: true
-        });
-
-        // Parse the locs file
+        symLinkCache.clear();
         this.loadingProject = true;
-        this.locsTrav.pass(ast);
-        const indexCount = this.locsTrav.promises.length;
 
-        // Wait for all files to finish
-        let i = 1;
-        this.locsTrav.token = token;
-        for (const [uri, prom] of this.locsTrav.promises) {
-            try {
-                progress.report({
-                    message: uri.path,
-                    increment: 100 / indexCount
-                });
-
-                await prom();
-            } catch { }
-            i++;
-        }
+        this.files = await this.workspace?.scan(progress, token) ?? new Set();
 
         this.loadingProject = false;
-        this.locsTrav.token = undefined;
-
-        // Annotate all the files at once
-        progress.report({
-            message: 'Refreshing project annotations',
-            increment: 0
-        });
-        this.refreshAnnotations();
-
-        // Force reparse of locs
-        await this.parse(this.locsFile, token, {
-            forceReparse: true
-        });
     }
 
-    private locsTrav = new class extends MemberTraverser {
-        parent!: FppProject;
-
-        newLocs = new Set<string>();
-        promises: [vscode.Uri, () => Promise<unknown>][] = [];
-        token?: vscode.CancellationToken;
-
-        pass(ast: Fpp.TranslationUnit): void {
-            this.newLocs.clear();
-            this.promises = [];
-
-            super.pass(ast);
-
-            this.parent.locs = this.newLocs;
-        }
-
-        protected locationStmt(ast: Fpp.LocationStmt, scope: Fpp.QualifiedIdentifier): void {
-            if (this.newLocs.has(ast.path.value)) {
-                // No need to double dip this file
-                return;
-            }
-
-            // Make sure we don't double parse a file
-            if (!this.newLocs.has(ast.path.value)) {
-                // Add the parsing file to the queue
-                const uri = vscode.Uri.file(ast.path.value);
-                this.promises.push([
-                    uri,
-                    () => {
-                        return this.parent.parse(uri, undefined, {
-                            disableAnnotations: true
-                        });
-                    }
-                ]);
-            }
-
-            this.newLocs.add(ast.path.value);
-        }
-    }();
-
     [Symbol.iterator](): Iterator<string> {
-        return this.locs.keys();
+        return this.files.keys();
     }
 
     async reload() {
         this.refreshLanguageStatus();
-        if (!this.locsFile) {
+        if (!this.workspace) {
             return;
         }
 
@@ -199,46 +103,55 @@ export class FppProject extends FppProjectManager implements vscode.Disposable {
             }, this.scan.bind(this));
         } catch (e) {
             console.error(e);
-            vscode.window.showErrorMessage(`Failed to load locs.fpp: ${e}`);
-            this.locsSelect.text = "Locs load failed";
-            this.locsSelect.severity = vscode.LanguageStatusSeverity.Error;
+            vscode.window.showErrorMessage(`Failed to load workspace: ${e}`);
+            this.projectSelect.text = "FPP workspace load failed";
+            this.projectSelect.severity = vscode.LanguageStatusSeverity.Error;
         } finally {
             this.locsReload.busy = false;
         }
     }
 
-    async set(locsFile: vscode.Uri | undefined) {
+    async index() {
+        this.projectSelect.busy = true;
+
+        try {
+            await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Notification,
+                title: "Indexing FPP Project",
+                cancellable: true
+            }, this.scan.bind(this));
+        } catch (e) {
+            console.error(e);
+            vscode.window.showErrorMessage(`Failed to load workspace: ${e}`);
+            this.projectSelect.text = "FPP workspace load failed";
+            this.projectSelect.severity = vscode.LanguageStatusSeverity.Error;
+        } finally {
+            this.projectSelect.busy = false;
+        }
+    }
+
+    async locsFile(locsFile: vscode.Uri | undefined) {
         if (!locsFile) {
-            this.locsFile = undefined;
+            this.workspace = undefined;
             this.clearAll();
             this.refreshLanguageStatus();
         } else {
-            this.locsFile = locsFile;
-
+            this.workspace = new LocsFileScanner(this, locsFile);
             this.refreshLanguageStatus();
-            this.locsSelect.busy = true;
-
-            try {
-                await vscode.window.withProgress({
-                    location: vscode.ProgressLocation.Notification,
-                    title: "Indexing FPP Project",
-                    cancellable: true
-                }, this.scan.bind(this));
-            } catch (e) {
-                console.error(e);
-                vscode.window.showErrorMessage(`Failed to load locs.fpp: ${e}`);
-                this.locsSelect.text = "Locs load failed";
-                this.locsSelect.severity = vscode.LanguageStatusSeverity.Error;
-            } finally {
-                this.locsSelect.busy = false;
-            }
+            await this.index();
         }
+    }
+
+    async workspaceScan() {
+        this.workspace = new EntireWorkspaceScanner(this);
+        this.refreshLanguageStatus();
+        await this.index();
     }
 
     dispose() {
         super.dispose();
-        this.locs.clear();
-        this.locsSelect.dispose();
+        this.files.clear();
+        this.projectSelect.dispose();
         this.locsReload.dispose();
     }
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,169 @@
+import * as vscode from 'vscode';
+
+import { FppProjectManager } from './manager';
+import { MemberTraverser } from './traverser';
+import * as Fpp from './parser/ast';
+import { symLinkCache } from './annotator';
+
+export interface WorkspaceFileScanner {
+    label(): string;
+
+    scan(
+        progress: vscode.Progress<{ message?: string; increment?: number }>,
+        token: vscode.CancellationToken,
+    ): Promise<Set<string>>;
+}
+
+export class LocsFileScanner implements WorkspaceFileScanner {
+    locsFile: vscode.Uri;
+    project: FppProjectManager;
+
+    private locsTrav = new class extends MemberTraverser {
+        parent!: LocsFileScanner;
+
+        files = new Set<string>();
+        promises: [vscode.Uri, () => Promise<unknown>][] = [];
+        token?: vscode.CancellationToken;
+
+        pass(ast: Fpp.TranslationUnit): void {
+            this.files.clear();
+            this.promises = [];
+
+            super.pass(ast);
+        }
+
+        protected locationStmt(ast: Fpp.LocationStmt, scope: Fpp.QualifiedIdentifier): void {
+            if (this.files.has(ast.path.value)) {
+                // No need to double dip this file
+                return;
+            }
+
+            // Make sure we don't double parse a file
+            if (!this.files.has(ast.path.value)) {
+                // Add the parsing file to the queue
+                const uri = vscode.Uri.file(ast.path.value);
+                this.promises.push([
+                    uri,
+                    () => {
+                        return this.parent.project.parse(uri, this.token, {
+                            disableAnnotations: true
+                        });
+                    }
+                ]);
+            }
+
+            this.files.add(ast.path.value);
+        }
+    }();
+
+    constructor(project: FppProjectManager, locsFile: vscode.Uri) {
+        this.project = project;
+        this.locsFile = locsFile;
+        this.locsTrav.parent = this;
+    }
+
+    label(): string {
+        return vscode.workspace.asRelativePath(this.locsFile);
+    }
+
+    async scan(
+        progress: vscode.Progress<{ message?: string; increment?: number }>,
+        token: vscode.CancellationToken,
+    ): Promise<Set<string>> {
+        // Read the locsFile file
+        progress.report({
+            message: "Scanning locs file",
+            increment: 0
+        });
+
+        // Parse the locs file
+        const { ast } = await this.project.parse(this.locsFile, token, {
+            forceReparse: true,
+            disableAnnotations: true
+        });
+
+        // Parse the locs file
+        this.locsTrav.files.clear();
+        this.locsTrav.pass(ast);
+        const indexCount = this.locsTrav.promises.length;
+
+        // Wait for all files to finish
+        let i = 1;
+        this.locsTrav.token = token;
+        for (const [uri, prom] of this.locsTrav.promises) {
+            try {
+                progress.report({
+                    message: uri.path,
+                    increment: 100 / indexCount
+                });
+
+                await prom();
+            } catch { }
+            i++;
+        }
+
+        this.locsTrav.token = undefined;
+
+        // Annotate all the files at once
+        progress.report({
+            message: 'Refreshing project annotations',
+            increment: 0
+        });
+
+        // Force reparse of locs
+        this.project.refreshAnnotations();
+        await this.project.parse(this.locsFile, token, {
+            forceReparse: true
+        });
+
+        return new Set(this.locsTrav.files.values());
+    }
+}
+
+
+export class EntireWorkspaceScanner implements WorkspaceFileScanner {
+    project: FppProjectManager;
+
+    constructor(project: FppProjectManager) {
+        this.project = project;
+    }
+
+    label(): string {
+        return "Workspace";
+    }
+
+    async scan(progress: vscode.Progress<{ message?: string; increment?: number; }>, token: vscode.CancellationToken): Promise<Set<string>> {
+        // Glob the entire workspace
+        progress.report({
+            message: "Scanning for .fpp files in workspace",
+            increment: 0
+        });
+
+        const allFppFiles = await vscode.workspace.findFiles("**/*.fpp", null, Infinity, token);
+
+        // Wait for all files to finish parsing
+        for (const uri of allFppFiles) {
+            try {
+                progress.report({
+                    message: uri.path,
+                    increment: 100 / allFppFiles.length
+                });
+
+                await this.project.parse(uri, token, {
+                    disableAnnotations: true
+                });
+            } catch { }
+        }
+
+        // Annotate all the files at once
+        progress.report({
+            message: 'Refreshing project annotations',
+            increment: 0
+        });
+
+        // Refresh project annotations
+        this.project.refreshAnnotations();
+
+        return new Set(allFppFiles.map(v => v.path));
+    }
+}


### PR DESCRIPTION
This PR adds a second workspace loading mode for loading all .fpp files in the entire VSCode workspace. It also fixes some bugs with .fppi files parsing even when there is no parent file associated with it.