### PR TITLE
Fix recursive type checking in complex expr types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/fprime-community/vscode-fpp",
         "type": "git"
     },
-    "version": "1.0.14",
+    "version": "1.0.15",
     "icon": "fprime-logo.png",
     "engines": {
         "vscode": "^1.78.0"

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -733,6 +733,7 @@ interface ExprValueBase<T> {
 
 export interface IntExprValue extends ExprValueBase<number> {
     type: PrimExprType.integer;
+    enumMember?: EnumMember;
 }
 
 export interface FloatExprValue extends ExprValueBase<number> {


### PR DESCRIPTION
Inner value types of arrays and structs were not being checked properly. This cleans up some of the type checking code to properly check those types. It also allows the logic to resolve type aliases in the expr type checking.