### PR TITLE
Cleanup vsce packaging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,12 +1,10 @@
-.vscode/**
-.vscode-test/**
-src/**
-.gitignore
-.yarnrc
-vsc-extension-quickstart.md
-**/tsconfig.json
-**/.eslintrc.json
-**/*.map
-**/*.ts
-*.vsix
-node_modules/**
+# Ignore everything and then selectively bring things back in
+.*
+**/*
+
+!dist/*
+!fprime-logo.png
+!CHANGELOG.md
+!README.md
+!package.json
+!LICENSE.txt

--- a/package.json
+++ b/package.json
@@ -168,8 +168,8 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "yarn package",
-        "package": "webpack --mode production --devtool hidden-source-map",
+        "vscode:prepublish": "rm -rf dist && yarn package",
+        "package": "webpack --mode production",
         "compile": "webpack --mode development",
         "watch": "webpack --mode development --watch",
         "antlr": "antlr4ts -visitor src/grammar/Fpp.g4 && node ./scripts/update-signatures.js src/signatures.json src/grammar/FppParser.ts"


### PR DESCRIPTION
This disables the source map from being generated in the dist (which wasn't actually packaged anyway). It also cleans up the `.vscodeignore` to only include the files we actually want in the package.