### PR TITLE
Do not run analysis on files outside the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.27] - 2025-08-06
+
+- Do not run analysis on files outside of the workspace
+
+## [1.0.26] - 2025-08-06
+
+- Run the entire compiler analysis on change to remove flakey diagnostics
+- Fix codelens attempting to parse _all_ files in VSCode as an FPP
+
 ## [1.0.25] - 2025-07-30
 
 - Annotate struct default expressions

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/fprime-community/vscode-fpp",
         "type": "git"
     },
-    "version": "1.0.26",
+    "version": "1.0.27",
     "icon": "fprime-logo.png",
     "engines": {
         "vscode": "^1.78.0"


### PR DESCRIPTION
This PR disables analysis on files that are not in the workspace. This keeps the parsing/syntax error reporting but does not do any annotation on these files since they could cause issues in the decl stage.