### PR TITLE
Fix infinite loop during semantic token classification

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -212,7 +212,7 @@
             },
             {
                 "id": "interface",
-                "superType": "interface",
+                "superType": "class",
                 "description": "A port interface definition or use"
             },
             {


### PR DESCRIPTION
This was a problem inside VSCode due to a circular reference in the semantic token classification. This was causing odd-10s freezes