### PR TITLE
Avoid line swallowing when there is an annotation on lists

### DIFF
--- a/fpp_format/src/formatter.rs
+++ b/fpp_format/src/formatter.rs
@@ -385,8 +385,13 @@ impl Item {
 
 fn attach(items: &mut [Item], extra: Doc) {
     if let Some(last) = items.last_mut() {
+        let sep = if last.comment {
+            Doc::hardline()
+        } else {
+            Doc::text(" ")
+        };
         let d = std::mem::replace(&mut last.doc, Doc::Nil);
-        last.doc = Doc::concat(vec![d, Doc::text(" "), extra]);
+        last.doc = Doc::concat(vec![d, sep, extra]);
         last.comment = true;
     }
 }

--- a/fpp_format/src/formatter.rs
+++ b/fpp_format/src/formatter.rs
@@ -57,7 +57,7 @@ impl Formatter {
                     RIGHT_CURLY | RIGHT_PAREN | RIGHT_SQUARE => {}
                     COMMENT => {
                         if saw_eol || items.is_empty() {
-                            items.push(Item::new(Doc::text(t.text()), blank));
+                            items.push(Item::line_swallowing(Doc::text(t.text()), blank));
                         } else {
                             attach(&mut items, Doc::text(t.text()));
                         }
@@ -66,14 +66,14 @@ impl Formatter {
                         started = true;
                     }
                     PRE_ANNOTATION => {
-                        items.push(Item::new(Doc::text(t.text()), blank));
+                        items.push(Item::line_swallowing(Doc::text(t.text()), blank));
                         saw_eol = false;
                         blank = false;
                         started = true;
                     }
                     POST_ANNOTATION => {
                         if items.is_empty() {
-                            items.push(Item::new(Doc::text(t.text()), blank));
+                            items.push(Item::line_swallowing(Doc::text(t.text()), blank));
                         } else {
                             attach(
                                 &mut items,
@@ -368,6 +368,17 @@ impl Item {
             doc,
             blank_before,
             comment: false,
+        }
+    }
+
+    /// An item whose text swallows the rest of its source line (a comment or an
+    /// annotation). Such items can never share a flat line with a sibling, so
+    /// they force their enclosing list to render as a block.
+    fn line_swallowing(doc: Doc, blank_before: bool) -> Self {
+        Item {
+            doc,
+            blank_before,
+            comment: true,
         }
     }
 }

--- a/fpp_format/tests/annotations.ref.fpp
+++ b/fpp_format/tests/annotations.ref.fpp
@@ -39,7 +39,8 @@ module AnnotatedModule {
     } @< Post-annotation for struct
 
     @ Constant with inline and post
-    constant MIN_VALUE = 0 # inline comment @< Post-annotation for constant
+    constant MIN_VALUE = 0 # inline comment
+    @< Post-annotation for constant
 
     # Final standalone comment
 } @< Post-annotation for module

--- a/fpp_format/tests/formatter.rs
+++ b/fpp_format/tests/formatter.rs
@@ -119,6 +119,7 @@ fmt_test!(component_extra, "component-extra");
 fmt_test!(multiline_string_align, "multiline-string-align");
 fmt_test!(constant_align, "constant-align");
 fmt_test!(enum_annotation_align, "enum-annotation-align");
+fmt_test!(param_annotation, "param-annotation");
 
 #[test]
 fn component_inner() {

--- a/fpp_format/tests/param-annotation.fpp
+++ b/fpp_format/tests/param-annotation.fpp
@@ -1,0 +1,16 @@
+module Fw {
+  @ Port for sending a buffer
+  port BufferSend(
+                   @ The buffer
+                   ref fwBuffer: Fw.Buffer
+                 )
+
+  @ Port for getting a buffer
+  port BufferGet(
+                  @ The requested size
+                  $size: FwSizeType
+                ) -> Fw.Buffer
+
+  @ A port whose params carry no annotations still flattens
+  port Plain(a: U32, b: U32)
+}

--- a/fpp_format/tests/param-annotation.ref.fpp
+++ b/fpp_format/tests/param-annotation.ref.fpp
@@ -1,0 +1,16 @@
+module Fw {
+    @ Port for sending a buffer
+    port BufferSend(
+        @ The buffer
+        ref fwBuffer: Fw.Buffer
+    )
+
+    @ Port for getting a buffer
+    port BufferGet(
+        @ The requested size
+        $size: FwSizeType
+    ) -> Fw.Buffer
+
+    @ A port whose params carry no annotations still flattens
+    port Plain(a: U32, b: U32)
+}


### PR DESCRIPTION
Fixes a formatting bug