### PR TITLE
Highlight,Go-To,Hover for port matching

### DIFF
--- a/fpp_lsp_server/src/handlers.rs
+++ b/fpp_lsp_server/src/handlers.rs
@@ -7,7 +7,8 @@ use crate::util::{
     completion_items_for_qual_ident, completion_items_for_sm, completion_items_for_sm_state,
     completion_items_in_name_group, hover_for_node, hover_for_port_instance, hover_for_sm_symbol,
     hover_for_symbol, node_to_location, nodes_at_offset, port_instance_at_position,
-    position_to_offset, sm_symbol_at_position, symbol_at_position, symbol_to_completion_item,
+    port_match_at_position, position_to_offset, sm_symbol_at_position, symbol_at_position,
+    symbol_to_completion_item,
 };
 use anyhow::Result;
 use fpp_analysis::semantics::{NameGroup, SymbolInterface};
@@ -522,6 +523,13 @@ pub fn handle_goto_definition(
             state,
             port_instance.get_node_id(),
         ))))
+    } else if let Some((_, port_instance)) = port_match_at_position(state, uri, offset) {
+        // Port names in a match specifier (`match a with b`) resolve to a port
+        // instance rather than a symbol; jump to its declaration.
+        Ok(Some(GotoDefinitionResponse::Scalar(node_to_location(
+            state,
+            port_instance.get_node_id(),
+        ))))
     } else if let Some((_, _, sm_symbol)) = sm_symbol_at_position(state, uri, offset) {
         // Uses inside a state machine resolve via the state machine's own
         // use-def map, not the global one; jump to the definition.
@@ -562,6 +570,21 @@ pub fn handle_hover(state: &GlobalState, request: HoverParams) -> Result<Option<
     // (sub)topology. `port_instance_at_position` only matches when the cursor is
     // on the port name, so it does not shadow the qualifier's own hover.
     if let Some((name_node, port_instance)) = port_instance_at_position(
+        state,
+        &request.text_document_position_params.text_document.uri,
+        offset,
+    ) {
+        return Ok(Some(hover_for_port_instance(
+            state,
+            name_node,
+            &port_instance,
+        )));
+    }
+
+    // Port names in a match specifier (`match a with b`) are bare identifiers,
+    // not symbols, so they are absent from use_def_map. Resolve them against the
+    // enclosing component's port map.
+    if let Some((name_node, port_instance)) = port_match_at_position(
         state,
         &request.text_document_position_params.text_document.uri,
         offset,

--- a/fpp_lsp_server/src/lsp/semantic_tokens.rs
+++ b/fpp_lsp_server/src/lsp/semantic_tokens.rs
@@ -8,7 +8,7 @@ use fpp_analysis::semantics::Symbol;
 use fpp_analysis::semantics::state_machine::StateMachineSymbol;
 use fpp_ast::{
     DefStateMachine, Expr, ExprKind, Ident, MoveWalkable, Node, PortInstanceIdentifier,
-    TlmChannelIdentifier, Visitor, Walkable,
+    SpecPortMatching, TlmChannelIdentifier, Visitor, Walkable,
 };
 use fpp_core::{LineCol, LineIndex, SourceFile, SourceFileData};
 use fpp_lsp_parser::{SyntaxKind, SyntaxNode, SyntaxToken, TextRange, VisitorResult};
@@ -419,6 +419,19 @@ impl<'ast> Visitor<'ast> for SemanticUses<'ast> {
         // Port instance is not a use, we need to mark it manually
         self.mark_node(a, node.port_name.node_id, SemanticTokenKind::PortInstance);
         node.interface_instance.walk(a, self)
+    }
+
+    fn visit_spec_port_matching(
+        &self,
+        a: &mut Self::State,
+        node: &'ast SpecPortMatching,
+    ) -> ControlFlow<Self::Break> {
+        // The two port names in a match specifier (`match a with b`) are bare
+        // identifiers, not uses in the use-def map, so mark them manually as
+        // port instances (matching how connection port names are colored).
+        self.mark_node(a, node.port1.node_id, SemanticTokenKind::PortInstance);
+        self.mark_node(a, node.port2.node_id, SemanticTokenKind::PortInstance);
+        ControlFlow::Continue(())
     }
 
     fn visit_def_state_machine(

--- a/fpp_lsp_server/src/util.rs
+++ b/fpp_lsp_server/src/util.rs
@@ -2,7 +2,7 @@ use crate::diagnostics::LspDiagnosticsEmitter;
 use crate::global_state::GlobalState;
 use fpp_analysis::semantics::state_machine::{StateMachine, StateMachineSymbol};
 use fpp_analysis::semantics::{
-    Direction, NameGroup, PortInstance, PortInstanceType, PortInterface, Scope, Symbol,
+    Component, Direction, NameGroup, PortInstance, PortInstanceType, PortInterface, Scope, Symbol,
     SymbolInterface, Type,
 };
 use fpp_ast::{AstNode, FormalParam, FormalParamKind, MoveWalkable, Name, Node, Visitor};
@@ -791,6 +791,74 @@ pub fn hover_for_port_instance(state: &GlobalState, hover_node: Node, pi: &PortI
         }),
         range: Some(node_to_range(state, hover_node.id())),
     }
+}
+
+/// Resolve a port-match specifier's port name at `position` to its underlying
+/// [`PortInstance`].
+///
+/// Port match specifiers (`match portA with portB`) name their two ports with
+/// bare [`fpp_ast::Ident`]s (raw string + span), not symbol references, so they
+/// are absent from `use_def_map` and are not handled by the generic hover/goto
+/// paths. Resolution mirrors `construct_port_matching` in `fpp_analysis`: look
+/// the name up in the enclosing component's `port_interface.port_map`.
+///
+/// Returns the port name's AST node (for locating/ranging the hover) together
+/// with the resolved port instance. Returns `None` if the cursor is not on one
+/// of the two port names, or the component/port does not resolve.
+pub(crate) fn port_match_at_position<'a>(
+    state: &'a GlobalState,
+    document: &Uri,
+    position: BytePos,
+) -> Option<(Node<'a>, PortInstance)> {
+    let nodes = nodes_at_offset(state, document, position)?;
+
+    // Find the enclosing port-match specifier and confirm the cursor is on one
+    // of its two port names.
+    let spec = nodes.iter().find_map(|n| match n {
+        Node::SpecPortMatching(spec) => Some(*spec),
+        _ => None,
+    })?;
+
+    let on_name = |name: &fpp_ast::Ident| -> bool {
+        let span = state
+            .context
+            .span_get(&state.context.node_get_span(&name.id()));
+        position >= span.start && position <= span.start + span.length
+    };
+    let name = if on_name(&spec.port1) {
+        &spec.port1
+    } else if on_name(&spec.port2) {
+        &spec.port2
+    } else {
+        return None;
+    };
+
+    // Resolve the enclosing component and look the port up by name, reusing the
+    // same lookup `construct_port_matching` performs. This is usable here
+    // because the request runs under `fpp_core::run_ref` (the compiler context
+    // is set on this thread).
+    let component = enclosing_component(state, &nodes)?;
+    let port_instance = component.port_interface.port_map.get(&name.data)?.clone();
+
+    // Look up the port name node among the resolved nodes for ranging.
+    let name_node = nodes
+        .iter()
+        .find(|n| n.id() == name.id())
+        .copied()
+        .unwrap_or(Node::SpecPortMatching(spec));
+
+    Some((name_node, port_instance))
+}
+
+/// The resolved component enclosing the cursor, if any, given the AST nodes
+/// covering the cursor position (innermost first).
+fn enclosing_component<'a>(state: &'a GlobalState, nodes: &[Node<'_>]) -> Option<&'a Component> {
+    let component_node = nodes.iter().find_map(|n| match n {
+        Node::DefComponent(def) => Some(*def),
+        _ => None,
+    })?;
+    let symbol = state.analysis.symbol_map.get(&component_node.node_id)?;
+    state.analysis.component_map.get(symbol)
 }
 
 /// Resolve a use inside a state machine at `position` to its state machine


### PR DESCRIPTION
Port names are not symbols and therefore do not exist in the use-def-map. This PR adds explicit LSP features for port names in a match
<img width="1031" height="232" alt="Screenshot 2026-08-10 at 9 42 57 AM" src="https://github.com/user-attachments/assets/440ec0cf-8861-4a82-9a50-89df75d041cf" />
