### PR TITLE
Clear blank line with trailing spaces

### DIFF
--- a/fpp_format/src/formatter.rs
+++ b/fpp_format/src/formatter.rs
@@ -42,13 +42,21 @@ impl Formatter {
         let mut saw_eol = false;
         let mut blank = false;
         let mut started = false;
+        // Newlines seen in the current run of trivia since the last real item.
+        // The lexer splits a blank line that carries trailing whitespace into
+        // separate EOL tokens (`"\n"` WHITESPACE `"\n"`), so a blank line must
+        // be detected by accumulating newlines across EOL tokens rather than
+        // looking for two newlines in a single token. WHITESPACE / COMMA / SEMI
+        // are transparent and do not reset the run.
+        let mut newlines = 0usize;
 
         for child in node.children_with_tokens() {
             if let Some(t) = child.as_token() {
                 match t.kind() {
                     WHITESPACE | COMMA | SEMI => {}
                     EOL => {
-                        if started && t.text().matches('\n').count() >= 2 {
+                        newlines += t.text().matches('\n').count();
+                        if started && newlines >= 2 {
                             blank = true;
                         }
                         saw_eol = true;
@@ -63,12 +71,14 @@ impl Formatter {
                         }
                         saw_eol = false;
                         blank = false;
+                        newlines = 0;
                         started = true;
                     }
                     PRE_ANNOTATION => {
                         items.push(Item::line_swallowing(Doc::text(t.text()), blank));
                         saw_eol = false;
                         blank = false;
+                        newlines = 0;
                         started = true;
                     }
                     POST_ANNOTATION => {
@@ -82,12 +92,14 @@ impl Formatter {
                         }
                         saw_eol = false;
                         blank = false;
+                        newlines = 0;
                         started = true;
                     }
                     _ => {
                         items.push(Item::new(Doc::text(t.text()), blank));
                         saw_eol = false;
                         blank = false;
+                        newlines = 0;
                         started = true;
                     }
                 }
@@ -95,6 +107,7 @@ impl Formatter {
                 items.push(Item::new(self.lower(n), blank));
                 saw_eol = false;
                 blank = false;
+                newlines = 0;
                 started = true;
             }
         }

--- a/fpp_format/src/lib.rs
+++ b/fpp_format/src/lib.rs
@@ -374,6 +374,42 @@ module Outer {
     }
 
     #[test]
+    fn test_blank_line_with_trailing_whitespace_is_preserved() {
+        // A blank separator line that carries trailing spaces is lexed as two
+        // EOL tokens around a WHITESPACE token; the blank must still be seen as
+        // a single intentional separator and preserved.
+        let input = "module M {\n  constant a = 1\n   \n  constant b = 2\n}\n";
+        let formatted =
+            format_text(input, TopEntryPoint::Module, FormatOptions::default()).unwrap();
+        assert_eq!(
+            formatted, "module M {\n  constant a = 1\n\n  constant b = 2\n}\n",
+            "trailing-whitespace blank line not preserved:\n{}",
+            formatted
+        );
+        // Same content without the stray spaces must format identically.
+        let clean = "module M {\n  constant a = 1\n\n  constant b = 2\n}\n";
+        let clean_formatted =
+            format_text(clean, TopEntryPoint::Module, FormatOptions::default()).unwrap();
+        assert_eq!(formatted, clean_formatted);
+        assert_stable(&formatted);
+    }
+
+    #[test]
+    fn test_multiple_blank_lines_with_whitespace_collapse_to_one() {
+        // Several blank lines (some carrying whitespace) collapse to a single
+        // separator, just like clean blank lines do.
+        let input = "module M {\n  constant a = 1\n \n\n  \n  constant b = 2\n}\n";
+        let formatted =
+            format_text(input, TopEntryPoint::Module, FormatOptions::default()).unwrap();
+        assert_eq!(
+            formatted, "module M {\n  constant a = 1\n\n  constant b = 2\n}\n",
+            "blank run not collapsed to one:\n{}",
+            formatted
+        );
+        assert_stable(&formatted);
+    }
+
+    #[test]
     fn test_short_spec_stays_inline() {
         // A spec under the width limit keeps its clauses on one line.
         let input = "module M { active component C { \


### PR DESCRIPTION
Fixes a formatter edge-case where blank lines with trailing spaces were not getting detected as blank lines and were getting removed.