### PR TITLE
VSCode Venv/LSP management

### DIFF
--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -26,6 +26,15 @@ When you open a `.fpp` file, the extension locates `fpp_lsp_server` automaticall
 If a venv is found but `fprime-fpp-lsp` is not installed, the extension offers to run
 `pip install fprime-fpp-lsp` for you and then starts the server.
 
+The **FPP Language Server** status item (in the language status menu, next to the FPP
+Project item) shows which binary was detected, its version, and where it came from. Click
+**Change** (or run **FPP: Select Language Server**) to browse for a specific executable or
+return to auto-discovery.
+
+For venv installs, the extension periodically checks PyPI for a newer `fprime-fpp-lsp` and
+offers to update it in place. Disable this with `fpp.checkForUpdates`, or trigger it
+manually with **FPP: Check for Language Server Update**.
+
 [py-ext]: https://marketplace.visualstudio.com/items?itemName=ms-python.python
 
 ### Build cache

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -32,6 +32,14 @@
                 "title": "FPP: Restart Language Server"
             },
             {
+                "command": "fpp.selectServer",
+                "title": "FPP: Select Language Server"
+            },
+            {
+                "command": "fpp.checkForServerUpdate",
+                "title": "FPP: Check for Language Server Update"
+            },
+            {
                 "command": "fpp.dumpActiveTextEditorSyntaxTree",
                 "title": "FPP (debug command): View CST"
             },
@@ -196,6 +204,11 @@
                 "fpp.pythonVenv": {
                     "type": "string",
                     "markdownDescription": "Path to the Python virtual environment root used to locate `fpp_lsp_server`. Overrides venv auto-discovery. Ignored when `#fpp.serverPath#` is set."
+                },
+                "fpp.checkForUpdates": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Periodically check PyPI for a newer `fprime-fpp-lsp` and prompt to update the language server in the workspace venv."
                 },
                 "fpp.locsSearch": {
                     "type": "array",

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -7,7 +7,8 @@ import {
 } from "vscode-languageclient/node";
 
 import * as Settings from "./settings";
-import { resolveServerPath } from "./serverPath";
+import { resolveServerPath, selectServer, ServerResolution } from "./serverPath";
+import { checkForUpdate, installedVersion } from "./serverVersion";
 import { LocsQuickPickFile, LocsQuickPickItem, LocsQuickPickType } from "./locs";
 import { dumpSyntaxTree, reloadWorkspace } from "./lsp_ext";
 import * as Config from "./fppLspConfig";
@@ -21,6 +22,11 @@ class FppExtension implements vscode.Disposable {
     private traceOutputChannel: vscode.OutputChannel;
 
     private projectStatus: vscode.LanguageStatusItem;
+    private serverStatus: vscode.LanguageStatusItem;
+
+    /** The most recent server resolution + detected version, for the update command. */
+    private resolved?: ServerResolution;
+    private installedVersion?: string;
 
     client?: LanguageClient;
 
@@ -35,6 +41,13 @@ class FppExtension implements vscode.Disposable {
         );
         this.projectStatus.name = "FPP Project";
         this.projectStatus.command = { title: "Select", command: "fpp.select" };
+
+        this.serverStatus = vscode.languages.createLanguageStatusItem(
+            'fpp.server', { language: "fpp" }
+        );
+        this.serverStatus.name = "FPP Language Server";
+        this.serverStatus.command = { title: "Change", command: "fpp.selectServer" };
+        this.refreshServerStatus(undefined);
 
         // The `.fpp-lsp` file is the source of truth for project config. Watch it so
         // the status reflects external edits (the server also reloads on change via
@@ -53,6 +66,7 @@ class FppExtension implements vscode.Disposable {
                 this.initializeClient();
             }),
             this.projectStatus,
+            this.serverStatus,
             configWatcher,
             this.outputChannel,
             this.traceOutputChannel,
@@ -71,10 +85,16 @@ class FppExtension implements vscode.Disposable {
         // Resolve the server executable: explicit setting, then the workspace venv
         // (installing `fprime-fpp-lsp` on request), then PATH. Shows its own
         // guidance if nothing is found.
-        const serverPath = await resolveServerPath();
-        if (!serverPath) {
+        const resolved = await resolveServerPath();
+        this.resolved = resolved;
+        this.installedVersion = resolved
+            ? await installedVersion(resolved.path)
+            : undefined;
+        this.refreshServerStatus(resolved, this.installedVersion);
+        if (!resolved) {
             return;
         }
+        const serverPath = resolved.path;
 
         const serverOptions: ServerOptions = {
             run: {
@@ -120,6 +140,28 @@ class FppExtension implements vscode.Disposable {
         } catch (e) {
             vscode.window.showErrorMessage(`Failed to start language server: ${e}`);
         }
+
+        // Poll PyPI for a newer server in the background (throttled + opt-out).
+        void this.checkForUpdate(false);
+    }
+
+    /**
+     * Check PyPI for a newer server and, if the user accepts an upgrade, restart
+     * the client. `force` bypasses the interval throttle (used by the command).
+     */
+    async checkForUpdate(force: boolean) {
+        if (!this.resolved) {
+            return;
+        }
+        const updated = await checkForUpdate(
+            this.context,
+            this.resolved,
+            this.installedVersion,
+            force
+        );
+        if (updated) {
+            await this.initializeClient();
+        }
     }
 
     /** Update the language-status item to reflect the current `.fpp-lsp` config. */
@@ -135,6 +177,31 @@ class FppExtension implements vscode.Disposable {
             this.projectStatus.text = `FPP: ${cfg.locs ?? cfg.buildCache}`;
             this.projectStatus.severity = vscode.LanguageStatusSeverity.Information;
         }
+    }
+
+    /** Update the language-status item that shows the detected server binary. */
+    private refreshServerStatus(resolved: ServerResolution | undefined, version?: string) {
+        if (!resolved) {
+            this.serverStatus.text = "No FPP language server found";
+            this.serverStatus.detail = undefined;
+            this.serverStatus.severity = vscode.LanguageStatusSeverity.Error;
+            return;
+        }
+
+        const origin: Record<ServerResolution["source"], string> = {
+            setting: "from fpp.serverPath",
+            venv: "from workspace venv",
+            installed: "installed into venv",
+            path: "found on PATH",
+        };
+        // Show a workspace-relative path when the binary lives inside a folder;
+        // asRelativePath leaves absolute paths and bare PATH commands unchanged.
+        const label = vscode.workspace.asRelativePath(resolved.path);
+        this.serverStatus.text = version
+            ? `FPP server ${version}: ${label}`
+            : `FPP server: ${label}`;
+        this.serverStatus.detail = origin[resolved.source];
+        this.serverStatus.severity = vscode.LanguageStatusSeverity.Information;
     }
 
     /** Ask the server to re-run project discovery and re-index. */
@@ -226,6 +293,14 @@ export async function activate(context: vscode.ExtensionContext) {
         extension,
         vscode.commands.registerCommand("fpp.restartLsp", async () => {
             await extension.initializeClient();
+        }),
+        vscode.commands.registerCommand("fpp.selectServer", async () => {
+            // A changed selection updates `fpp.serverPath`, and the
+            // onLspServerPathChanged listener restarts the client with the new path.
+            await selectServer();
+        }),
+        vscode.commands.registerCommand("fpp.checkForServerUpdate", async () => {
+            await extension.checkForUpdate(true);
         }),
         vscode.commands.registerCommand('fpp.reload', extension.reload.bind(extension)),
         vscode.commands.registerCommand('fpp.load', (file?: vscode.Uri) => {

--- a/editors/code/src/serverPath.ts
+++ b/editors/code/src/serverPath.ts
@@ -20,7 +20,7 @@ import * as Settings from './settings';
  */
 
 /** The distribution name on PyPI. */
-const PIP_PACKAGE = 'fprime-fpp-lsp';
+export const PIP_PACKAGE = 'fprime-fpp-lsp';
 
 /** The console-script executable installed by the wheel. */
 const EXE_NAME = 'fpp_lsp_server';
@@ -77,6 +77,15 @@ async function pathExists(p: string): Promise<boolean> {
     } catch {
         return false;
     }
+}
+
+/**
+ * Whether a directory is a real virtual environment. A venv is marked by a
+ * `pyvenv.cfg` at its root; a global/system interpreter (e.g. `/usr`) has none,
+ * and we must not treat it as a venv to install into.
+ */
+function isVenv(root: string): Promise<boolean> {
+    return pathExists(path.join(root, 'pyvenv.cfg'));
 }
 
 /**
@@ -139,6 +148,12 @@ async function venvFromPythonExtension(
             return undefined;
         }
         const venvRoot = resolved?.executable.sysPrefix ?? venvRootFromInterpreter(interpreter);
+        // Only accept a real venv. A global/system interpreter (e.g. /usr/bin/python
+        // → /usr) is not something we should offer to pip-install into; fall through
+        // to scanning for a project venv instead.
+        if (!(await isVenv(venvRoot))) {
+            return undefined;
+        }
         return await venvInfoFromInterpreter(interpreter, venvRoot);
     } catch {
         // The Python extension is optional; any failure just falls through to scanning.
@@ -155,8 +170,7 @@ async function venvFromScan(): Promise<VenvInfo | undefined> {
     // `fprime-venv` is the canonical venv name for F Prime projects; check it first.
     for (const name of ['fprime-venv', '.venv', 'venv', 'env']) {
         const root = path.join(folder.uri.fsPath, name);
-        // A real venv has a `pyvenv.cfg` marker at its root.
-        if (await pathExists(path.join(root, 'pyvenv.cfg'))) {
+        if (await isVenv(root)) {
             return await venvInfo(root);
         }
     }
@@ -170,6 +184,13 @@ async function venvFromScan(): Promise<VenvInfo | undefined> {
 async function findVenv(): Promise<VenvInfo | undefined> {
     const override = Settings.pythonVenv();
     if (override) {
+        if (!(await isVenv(override))) {
+            vscode.window.showWarningMessage(
+                `fpp.pythonVenv (${override}) is not a Python virtual environment ` +
+                    '(no pyvenv.cfg found).'
+            );
+            return undefined;
+        }
         return await venvInfo(override);
     }
 
@@ -178,30 +199,21 @@ async function findVenv(): Promise<VenvInfo | undefined> {
 }
 
 /**
- * Prompt the user to install `fprime-fpp-lsp` into the given venv and run
- * `python -m pip install` as a task. Resolves to true if the install completed
- * successfully.
+ * Run `python -m pip install [--upgrade] fprime-fpp-lsp` in the given venv as a
+ * task. Resolves to true if pip exited successfully.
  */
-async function promptInstall(venv: VenvInfo): Promise<boolean> {
-    const choice = await vscode.window.showInformationMessage(
-        `${PIP_PACKAGE} is not installed in the workspace venv (${venv.venvRoot}). Install it?`,
-        'Install',
-        'Cancel'
-    );
-    if (choice !== 'Install') {
-        return false;
+export async function pipInstall(pythonPath: string, upgrade: boolean): Promise<boolean> {
+    const args = ['-m', 'pip', 'install'];
+    if (upgrade) {
+        args.push('--upgrade');
     }
+    args.push(PIP_PACKAGE);
 
-    const execution = new vscode.ShellExecution(venv.pythonPath, [
-        '-m',
-        'pip',
-        'install',
-        PIP_PACKAGE,
-    ]);
+    const execution = new vscode.ShellExecution(pythonPath, args);
     const task = new vscode.Task(
         { type: 'fpp-pip-install' },
         vscode.TaskScope.Workspace,
-        `Install ${PIP_PACKAGE}`,
+        `${upgrade ? 'Update' : 'Install'} ${PIP_PACKAGE}`,
         'fpp',
         execution
     );
@@ -220,32 +232,63 @@ async function promptInstall(venv: VenvInfo): Promise<boolean> {
         return true;
     }
     vscode.window.showErrorMessage(
-        `Failed to install ${PIP_PACKAGE} (pip exited with code ${exitCode}).`
+        `Failed to ${upgrade ? 'update' : 'install'} ${PIP_PACKAGE} (pip exited with code ${exitCode}).`
     );
     return false;
+}
+
+/**
+ * Prompt the user to install `fprime-fpp-lsp` into the given venv. Resolves to
+ * true if the install completed successfully.
+ */
+async function promptInstall(venv: VenvInfo): Promise<boolean> {
+    const choice = await vscode.window.showInformationMessage(
+        `${PIP_PACKAGE} is not installed in the workspace venv (${venv.venvRoot}). Install it?`,
+        'Install',
+        'Cancel'
+    );
+    if (choice !== 'Install') {
+        return false;
+    }
+    return await pipInstall(venv.pythonPath, false);
+}
+
+/** Where a resolved server executable came from. */
+export type ServerSource = 'setting' | 'venv' | 'installed' | 'path';
+
+/** A resolved server executable and how it was discovered. */
+export interface ServerResolution {
+    /** The command/path to launch (may be a bare `fpp_lsp_server` for the PATH case). */
+    path: string;
+    source: ServerSource;
+    /**
+     * The venv Python interpreter that owns this executable, when it came from a
+     * venv. Used to run pip upgrades against the right environment.
+     */
+    pythonPath?: string;
 }
 
 /**
  * Resolve the server executable to launch, or `undefined` if none could be found
  * and the user declined to install one. May show install prompts / error messages.
  */
-export async function resolveServerPath(): Promise<string | undefined> {
+export async function resolveServerPath(): Promise<ServerResolution | undefined> {
     // 1. Explicit setting wins (ignore the legacy `<default>` sentinel).
     const configured = Settings.serverPath();
     if (configured && configured !== DEFAULT_SENTINEL) {
-        return configured;
+        return { path: configured, source: 'setting' };
     }
 
     // 2. Executable inside the workspace venv.
     const venv = await findVenv();
     if (venv?.exeExists) {
-        return venv.exePath;
+        return { path: venv.exePath, source: 'venv', pythonPath: venv.pythonPath };
     }
 
     // 3. `fpp_lsp_server` on PATH (venv activated in the user's shell, or global install).
     //    LanguageClient spawns via the shell's PATH, so a bare command works if resolvable.
     if (await onPath()) {
-        return EXE_NAME;
+        return { path: EXE_NAME, source: 'path' };
     }
 
     // 4. Venv found but package missing — offer to install, then re-resolve.
@@ -253,7 +296,7 @@ export async function resolveServerPath(): Promise<string | undefined> {
         if (await promptInstall(venv)) {
             const after = await venvInfo(venv.venvRoot);
             if (after.exeExists) {
-                return after.exePath;
+                return { path: after.exePath, source: 'installed', pythonPath: after.pythonPath };
             }
         }
         return undefined;
@@ -272,6 +315,69 @@ export async function resolveServerPath(): Promise<string | undefined> {
         );
     }
     return undefined;
+}
+
+/**
+ * Let the user change which server executable is used. Offers browsing for an
+ * executable (persisted to `fpp.serverPath`) or clearing the override to return
+ * to auto-discovery. Returns true if the selection changed.
+ */
+export async function selectServer(): Promise<boolean> {
+    const configured = Settings.serverPath();
+    const hasOverride = !!configured && configured !== DEFAULT_SENTINEL;
+
+    interface Item extends vscode.QuickPickItem {
+        action: 'browse' | 'auto';
+    }
+    const items: Item[] = [
+        {
+            label: '$(folder-opened) Browse for executable…',
+            detail: 'Pick an `fpp_lsp_server` binary and save it to `fpp.serverPath`.',
+            action: 'browse',
+        },
+        {
+            label: '$(sync) Auto-discover',
+            detail: 'Clear `fpp.serverPath` and detect the server from the venv or PATH.',
+            description: hasOverride ? undefined : '(current)',
+            action: 'auto',
+        },
+    ];
+
+    const picked = await vscode.window.showQuickPick(items, {
+        title: 'Select FPP language server',
+        canPickMany: false,
+    });
+    if (!picked) {
+        return false;
+    }
+
+    const target = vscode.workspace.workspaceFolders?.length
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.Global;
+    const config = vscode.workspace.getConfiguration();
+
+    if (picked.action === 'auto') {
+        if (!hasOverride) {
+            return false;
+        }
+        await config.update('fpp.serverPath', undefined, target);
+        return true;
+    }
+
+    // Browse for an executable.
+    const choice = await vscode.window.showOpenDialog({
+        openLabel: 'Select server',
+        canSelectFiles: true,
+        canSelectFolders: false,
+        canSelectMany: false,
+        defaultUri: hasOverride ? vscode.Uri.file(configured) : undefined,
+        title: 'Select the fpp_lsp_server executable',
+    });
+    if (!choice?.length) {
+        return false;
+    }
+    await config.update('fpp.serverPath', choice[0].fsPath, target);
+    return true;
 }
 
 /** Check whether `fpp_lsp_server` is resolvable on the current `PATH`. */

--- a/editors/code/src/serverVersion.ts
+++ b/editors/code/src/serverVersion.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { execFile } from 'child_process';
-import * as https from 'https';
 
 import * as Settings from './settings';
 import { PIP_PACKAGE, pipInstall, ServerResolution } from './serverPath';
@@ -34,34 +33,44 @@ export function installedVersion(serverPath: string): Promise<string | undefined
     });
 }
 
-/** Fetch the latest released version of the package from PyPI. */
-function latestVersion(): Promise<string | undefined> {
-    return new Promise((resolve) => {
-        const req = https.get(
-            `https://pypi.org/pypi/${PIP_PACKAGE}/json`,
-            { headers: { 'Accept': 'application/json' }, timeout: 5000 },
-            (res) => {
-                if (res.statusCode !== 200) {
-                    res.resume();
-                    resolve(undefined);
-                    return;
-                }
-                let body = '';
-                res.setEncoding('utf8');
-                res.on('data', (chunk) => (body += chunk));
-                res.on('end', () => {
-                    try {
-                        const version = JSON.parse(body)?.info?.version;
-                        resolve(typeof version === 'string' ? version : undefined);
-                    } catch {
-                        resolve(undefined);
-                    }
-                });
-            }
-        );
-        req.on('timeout', () => req.destroy());
-        req.on('error', () => resolve(undefined));
-    });
+/** Result of a PyPI lookup: the version, or a human-readable failure reason. */
+interface LatestResult {
+    version?: string;
+    error?: string;
+}
+
+/**
+ * Fetch the latest released version of the package from PyPI.
+ *
+ * Uses the global `fetch` (undici, provided by VSCode's Node runtime) rather
+ * than the `https` module: VSCode's proxy agent monkey-patches `https` when
+ * `http.proxySupport` is `override` (the default), and its llhttp parser can
+ * fail on some responses with "Parse Error: JS Exception". `fetch` avoids that
+ * patched path while still honoring the user's proxy. On any failure we return a
+ * reason string so the caller can surface it.
+ */
+async function latestVersion(): Promise<LatestResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+    try {
+        const res = await fetch(`https://pypi.org/pypi/${PIP_PACKAGE}/json`, {
+            headers: { 'Accept': 'application/json', 'User-Agent': 'fpp-vscode-extension' },
+            signal: controller.signal,
+        });
+        if (!res.ok) {
+            return { error: `PyPI returned HTTP ${res.status}` };
+        }
+        const data = await res.json() as { info?: { version?: unknown } };
+        const version = data?.info?.version;
+        return typeof version === 'string'
+            ? { version }
+            : { error: 'PyPI response missing info.version' };
+    } catch (e) {
+        const err = e as Error;
+        return { error: err.name === 'AbortError' ? 'request timed out' : err.message };
+    } finally {
+        clearTimeout(timeout);
+    }
 }
 
 /**
@@ -117,17 +126,20 @@ export async function checkForUpdate(
         }
     }
 
-    const latest = await latestVersion();
-    // Record the attempt regardless of outcome so we throttle network calls.
-    await context.globalState.update(LAST_CHECK_KEY, Date.now());
+    const { version: latest, error } = await latestVersion();
     if (!latest) {
+        // Don't advance the throttle on failure, so the next window reload retries
+        // rather than staying silent for a day on a transient network blip.
         if (force) {
             vscode.window.showWarningMessage(
-                `FPP: could not reach PyPI to check for ${PIP_PACKAGE} updates.`
+                `FPP: could not reach PyPI to check for ${PIP_PACKAGE} updates` +
+                    (error ? ` (${error}).` : '.')
             );
         }
         return false;
     }
+    // Successful fetch — record it so we don't re-poll for the interval.
+    await context.globalState.update(LAST_CHECK_KEY, Date.now());
 
     if (compareVersions(latest, installed) <= 0) {
         if (force) {

--- a/editors/code/src/serverVersion.ts
+++ b/editors/code/src/serverVersion.ts
@@ -1,0 +1,159 @@
+import * as vscode from 'vscode';
+import { execFile } from 'child_process';
+import * as https from 'https';
+
+import * as Settings from './settings';
+import { PIP_PACKAGE, pipInstall, ServerResolution } from './serverPath';
+
+/**
+ * Installed-version detection and PyPI update checks for `fprime-fpp-lsp`.
+ *
+ * The server binary is a clap program built with `#[command(version)]`, so
+ * `fpp_lsp_server --version` prints its package version. We compare that against
+ * the latest release on PyPI and, when newer, offer to `pip install --upgrade`.
+ */
+
+/** How often to poll PyPI, at most, regardless of window reloads. */
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const LAST_CHECK_KEY = 'fpp.lastUpdateCheck';
+/** A `version` the user chose to skip; we won't re-prompt for it. */
+const SKIPPED_VERSION_KEY = 'fpp.skippedUpdateVersion';
+
+/** Run `<exe> --version` and return the parsed semver-ish string, or undefined. */
+export function installedVersion(serverPath: string): Promise<string | undefined> {
+    return new Promise((resolve) => {
+        execFile(serverPath, ['--version'], { timeout: 5000 }, (err, stdout) => {
+            if (err) {
+                resolve(undefined);
+                return;
+            }
+            // clap prints e.g. "fpp_lsp_server 0.3.1"; grab the version token.
+            const match = stdout.match(/(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)/);
+            resolve(match?.[1]);
+        });
+    });
+}
+
+/** Fetch the latest released version of the package from PyPI. */
+function latestVersion(): Promise<string | undefined> {
+    return new Promise((resolve) => {
+        const req = https.get(
+            `https://pypi.org/pypi/${PIP_PACKAGE}/json`,
+            { headers: { 'Accept': 'application/json' }, timeout: 5000 },
+            (res) => {
+                if (res.statusCode !== 200) {
+                    res.resume();
+                    resolve(undefined);
+                    return;
+                }
+                let body = '';
+                res.setEncoding('utf8');
+                res.on('data', (chunk) => (body += chunk));
+                res.on('end', () => {
+                    try {
+                        const version = JSON.parse(body)?.info?.version;
+                        resolve(typeof version === 'string' ? version : undefined);
+                    } catch {
+                        resolve(undefined);
+                    }
+                });
+            }
+        );
+        req.on('timeout', () => req.destroy());
+        req.on('error', () => resolve(undefined));
+    });
+}
+
+/**
+ * Compare two dotted version strings. Returns >0 if `a` > `b`, <0 if `a` < `b`,
+ * 0 if equal. Pre-release/build suffixes on a component are ignored for ordering.
+ */
+export function compareVersions(a: string, b: string): number {
+    const parts = (v: string) =>
+        v.split('.').map((p) => parseInt(p, 10) || 0);
+    const pa = parts(a);
+    const pb = parts(b);
+    const len = Math.max(pa.length, pb.length);
+    for (let i = 0; i < len; i++) {
+        const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+        if (d !== 0) {
+            return d > 0 ? 1 : -1;
+        }
+    }
+    return 0;
+}
+
+/**
+ * Check PyPI for a newer `fprime-fpp-lsp` and, if the resolved server lives in a
+ * venv we can upgrade, prompt the user. `force` bypasses the interval throttle
+ * and the "skipped version" memory (used by the manual command).
+ *
+ * Returns true if an upgrade was installed (so the caller can restart the client).
+ */
+export async function checkForUpdate(
+    context: vscode.ExtensionContext,
+    resolved: ServerResolution,
+    installed: string | undefined,
+    force: boolean
+): Promise<boolean> {
+    if (!force && !Settings.checkForUpdates()) {
+        return false;
+    }
+    // We can only offer an in-place upgrade for venv installs.
+    if (!resolved.pythonPath || !installed) {
+        if (force) {
+            vscode.window.showInformationMessage(
+                'FPP: automatic updates are only available for venv installs of ' +
+                    `${PIP_PACKAGE}.`
+            );
+        }
+        return false;
+    }
+
+    if (!force) {
+        const last = context.globalState.get<number>(LAST_CHECK_KEY) ?? 0;
+        if (Date.now() - last < CHECK_INTERVAL_MS) {
+            return false;
+        }
+    }
+
+    const latest = await latestVersion();
+    // Record the attempt regardless of outcome so we throttle network calls.
+    await context.globalState.update(LAST_CHECK_KEY, Date.now());
+    if (!latest) {
+        if (force) {
+            vscode.window.showWarningMessage(
+                `FPP: could not reach PyPI to check for ${PIP_PACKAGE} updates.`
+            );
+        }
+        return false;
+    }
+
+    if (compareVersions(latest, installed) <= 0) {
+        if (force) {
+            vscode.window.showInformationMessage(
+                `FPP: ${PIP_PACKAGE} is up to date (${installed}).`
+            );
+        }
+        return false;
+    }
+
+    if (!force && context.globalState.get<string>(SKIPPED_VERSION_KEY) === latest) {
+        return false;
+    }
+
+    const choice = await vscode.window.showInformationMessage(
+        `A new FPP language server is available (${installed} → ${latest}). Update?`,
+        'Update',
+        'Skip This Version'
+    );
+    if (choice === 'Skip This Version') {
+        await context.globalState.update(SKIPPED_VERSION_KEY, latest);
+        return false;
+    }
+    if (choice !== 'Update') {
+        return false;
+    }
+
+    return await pipInstall(resolved.pythonPath, true);
+}

--- a/editors/code/src/settings.ts
+++ b/editors/code/src/settings.ts
@@ -5,6 +5,7 @@ const names = {
     locsExclude: "fpp.locsExclude",
     serverPath: "fpp.serverPath",
     pythonVenv: "fpp.pythonVenv",
+    checkForUpdates: "fpp.checkForUpdates",
     lspServerRunLogLevel: "fpp.lspServerRunLogLevel",
     lspServerDevLogLevel: "fpp.lspServerDevLogLevel"
 };
@@ -53,6 +54,14 @@ export function onPythonVenvChanged(callback: () => void): vscode.Disposable {
             callback();
         }
     });
+}
+
+/**
+ * Whether to periodically poll PyPI for a newer `fprime-fpp-lsp` and prompt to
+ * update. Defaults to true.
+ */
+export function checkForUpdates(): boolean {
+    return vscode.workspace.getConfiguration().get<boolean>(names.checkForUpdates) ?? true;
 }
 
 type LogLevel = (


### PR DESCRIPTION
This PR adds a tool to the VSCode extension for displaying/managing the LSP server binary. It detects updates to the LSP have been pushed to PyPI and prompts the user to update. This also fixes a venv detection bug