### PR TITLE
Diagram layout options, analysis debounce & diagnostic push

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,17 +240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "drop_bomb"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,15 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
 ]
 
 [[package]]
@@ -409,13 +389,13 @@ dependencies = [
  "ignore",
  "lsp-server",
  "lsp-types",
+ "percent-encoding",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "tracing",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]
@@ -501,108 +481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,12 +549,6 @@ dependencies = [
  "nohash-hasher",
  "text-size",
 ]
-
-[[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
@@ -772,15 +644,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "pretty_assertions"
@@ -967,12 +830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,16 +870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -1104,24 +951,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1333,90 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -106,6 +106,12 @@
                 "title": "FPP: Toggle Transition Action Mode",
                 "icon": "$(list-flat)",
                 "category": "FPP Diagram"
+            },
+            {
+                "command": "fpp.stateMachine.view-source",
+                "title": "FPP: View Diagram Mermaid Source",
+                "icon": "$(code)",
+                "category": "FPP Diagram"
             }
         ],
         "languages": [
@@ -151,37 +157,42 @@
                 },
                 {
                     "command": "fpp.diagram.fit",
-                    "when": "fppDiagrams-focused == true",
+                    "when": "activeWebviewPanelId == 'fppDiagrams'",
                     "group": "navigation"
                 },
                 {
                     "command": "fpp.diagram.center",
-                    "when": "fppDiagrams-focused == true",
+                    "when": "activeWebviewPanelId == 'fppDiagrams'",
                     "group": "navigation"
                 },
                 {
                     "command": "fpp.diagram.export",
-                    "when": "fppDiagrams-focused == true",
+                    "when": "activeWebviewPanelId == 'fppDiagrams'",
                     "group": "navigation"
                 },
                 {
                     "command": "fpp.diagram.toggle-unused-ports",
-                    "when": "fppDiagrams-focused == true",
+                    "when": "activeWebviewPanelId == 'fppDiagrams'",
                     "group": "navigation"
                 },
                 {
                     "command": "fpp.stateMachine.fit",
-                    "when": "fppStateMachineDiagram-focused == true",
+                    "when": "activeWebviewPanelId == 'fppStateMachineDiagram'",
                     "group": "navigation"
                 },
                 {
                     "command": "fpp.stateMachine.export",
-                    "when": "fppStateMachineDiagram-focused == true",
+                    "when": "activeWebviewPanelId == 'fppStateMachineDiagram'",
+                    "group": "navigation"
+                },
+                {
+                    "command": "fpp.stateMachine.view-source",
+                    "when": "activeWebviewPanelId == 'fppStateMachineDiagram'",
                     "group": "navigation"
                 },
                 {
                     "command": "fpp.stateMachine.toggle-action-mode",
-                    "when": "fppStateMachineDiagram-focused == true",
+                    "when": "activeWebviewPanelId == 'fppStateMachineDiagram'",
                     "group": "navigation"
                 }
             ],

--- a/editors/code/src/diagram/index.ts
+++ b/editors/code/src/diagram/index.ts
@@ -98,7 +98,7 @@ export function registerDiagramSupport(
             "fpp.displayDiagram",
             (diagramType: DiagramType, name: string, uri?: vscode.Uri) => {
                 if (diagramType === DiagramType.stateMachine) {
-                    return mermaidPanel.show(name);
+                    return mermaidPanel.show(name, uri);
                 }
                 return webviewPanelManager.displayDiagram(diagramType, name, uri);
             }
@@ -110,6 +110,7 @@ export function registerDiagramSupport(
         }),
         vscode.commands.registerCommand("fpp.stateMachine.fit", () => mermaidPanel.fit()),
         vscode.commands.registerCommand("fpp.stateMachine.export", () => mermaidPanel.export()),
+        vscode.commands.registerCommand("fpp.stateMachine.view-source", () => mermaidPanel.viewSource()),
         vscode.commands.registerCommand("fpp.stateMachine.toggle-action-mode", () => mermaidPanel.toggleActionMode()),
         vscode.languages.registerCodeLensProvider({ language: "fpp" }, codeLensProvider),
         // Re-render the open diagram(s) (and refresh lenses) when an FPP file is saved.

--- a/editors/code/src/diagram/mermaid-panel.ts
+++ b/editors/code/src/diagram/mermaid-panel.ts
@@ -15,10 +15,111 @@ import * as lsp_ext from "../lsp_ext";
 /** A provider of the current language client (recreated on restart). */
 export type ClientProvider = () => LanguageClient | undefined;
 
+/**
+ * ELK layout options for a state machine diagram. These live in the FPP source
+ * as a `@ diagram-layout ...` annotation and are embedded by the language server
+ * into the Mermaid frontmatter; the panel parses them from there (to drive the
+ * gear popover) and writes changes back to the source. Values are the ELK option
+ * strings Mermaid's ELK backend expects.
+ */
+interface LayoutOptions {
+    /** The Mermaid layout backend: `elk` or `dagre`. */
+    engine: string;
+    /** Flow direction (both engines): `TB`, `BT`, `LR`, or `RL`. */
+    direction: string;
+    cycleBreaking: string;
+    considerModelOrder: string;
+    nodePlacement: string;
+    /** Node spacing in px, as a string (dagre only). */
+    nodeSpacing: string;
+    /** Rank spacing in px, as a string (dagre only). */
+    rankSpacing: string;
+}
+
+/** Defaults; must match `fpp_diagram`'s `SmLayout::default()`. */
+const DEFAULT_LAYOUT: LayoutOptions = {
+    engine: "elk",
+    direction: "TB",
+    cycleBreaking: "MODEL_ORDER",
+    considerModelOrder: "NODES_AND_EDGES",
+    nodePlacement: "BRANDES_KOEPF",
+    nodeSpacing: "60",
+    rankSpacing: "60",
+};
+
+/** The layout option keys, used to validate messages from the webview. */
+const LAYOUT_KEYS: readonly (keyof LayoutOptions)[] = [
+    "engine",
+    "direction",
+    "cycleBreaking",
+    "considerModelOrder",
+    "nodePlacement",
+    "nodeSpacing",
+    "rankSpacing",
+];
+
+/**
+ * Read the layout options out of a Mermaid source: the engine and ELK/spacing
+ * options from the YAML frontmatter, and the flow direction from the `direction`
+ * statement in the diagram body.
+ */
+function parseLayoutFromMermaid(text: string): LayoutOptions {
+    const grab = (re: RegExp) => text.match(re)?.[1];
+    return {
+        engine: grab(/^\s*layout:\s*(\S+)/m) ?? DEFAULT_LAYOUT.engine,
+        direction: grab(/^\s*direction\s+(\S+)/m) ?? DEFAULT_LAYOUT.direction,
+        nodePlacement: grab(/nodePlacementStrategy:\s*(\S+)/) ?? DEFAULT_LAYOUT.nodePlacement,
+        cycleBreaking: grab(/cycleBreakingStrategy:\s*(\S+)/) ?? DEFAULT_LAYOUT.cycleBreaking,
+        considerModelOrder:
+            grab(/considerModelOrder:\s*(\S+)/) ?? DEFAULT_LAYOUT.considerModelOrder,
+        nodeSpacing: grab(/nodeSpacing:\s*(\S+)/) ?? DEFAULT_LAYOUT.nodeSpacing,
+        rankSpacing: grab(/rankSpacing:\s*(\S+)/) ?? DEFAULT_LAYOUT.rankSpacing,
+    };
+}
+
+/**
+ * Rewrite a Mermaid source to reflect `layout` (optimistic update).
+ *
+ * The webview drives the effective layout from the `layout` object passed in the
+ * `render` message, not from this text, so this rewrite only needs to keep the
+ * source in sync for "view source": the `layout:` engine line, the ELK/spacing
+ * frontmatter values, and the body `direction` statement. Lines that are absent
+ * for the current engine (e.g. the spacing block under ELK) are simply not
+ * matched; the values are re-emitted from the source annotation on the next
+ * language-server round-trip.
+ */
+function applyLayoutToMermaid(text: string, layout: LayoutOptions): string {
+    return text
+        .replace(/(^\s*layout:\s*)\S+/m, `$1${layout.engine}`)
+        .replace(/(^\s*direction\s+)\S+/m, `$1${layout.direction}`)
+        .replace(/(nodePlacementStrategy:\s*)\S+/, `$1${layout.nodePlacement}`)
+        .replace(/(cycleBreakingStrategy:\s*)\S+/, `$1${layout.cycleBreaking}`)
+        .replace(/(considerModelOrder:\s*)\S+/, `$1${layout.considerModelOrder}`)
+        .replace(/(nodeSpacing:\s*)\S+/, `$1${layout.nodeSpacing}`)
+        .replace(/(rankSpacing:\s*)\S+/, `$1${layout.rankSpacing}`);
+}
+
+/** The `diagram-layout` annotation *body* (without the `@ ` marker) for `layout`. */
+function layoutToAnnotation(layout: LayoutOptions): string {
+    return (
+        `diagram-layout engine=${layout.engine}` +
+        ` direction=${layout.direction}` +
+        ` cycleBreaking=${layout.cycleBreaking}` +
+        ` considerModelOrder=${layout.considerModelOrder}` +
+        ` nodePlacement=${layout.nodePlacement}` +
+        ` nodeSpacing=${layout.nodeSpacing}` +
+        ` rankSpacing=${layout.rankSpacing}`
+    );
+}
+
 export class MermaidStateMachinePanel {
     private panel: vscode.WebviewPanel | undefined;
     /** The fully qualified name of the state machine currently shown. */
     private currentName: string | undefined;
+    /** URI of the source `.fpp`/`.fppi` file defining the current state machine. */
+    private sourceUri: vscode.Uri | undefined;
+    /** The Mermaid source most recently rendered, for the "view source" action. */
+    private currentText: string | undefined;
     /** Whether the webview has signalled it is ready to receive diagrams. */
     private ready = false;
     /** Text awaiting a not-yet-ready webview. */
@@ -32,8 +133,9 @@ export class MermaidStateMachinePanel {
     ) {}
 
     /** Show (creating if needed) the state machine `name`, revealing the panel. */
-    async show(name: string): Promise<void> {
+    async show(name: string, sourceUri?: vscode.Uri): Promise<void> {
         this.currentName = name;
+        this.sourceUri = sourceUri;
         if (!this.panel) {
             this.createPanel();
         } else {
@@ -67,7 +169,29 @@ export class MermaidStateMachinePanel {
             vscode.window.showErrorMessage(`Failed to generate diagram: ${e}`);
             return;
         }
+        this.currentText = text;
         this.post(text);
+    }
+
+    /**
+     * Open the current Mermaid source in an editor for inspection/copying. The
+     * language server already embeds the layout options as YAML frontmatter, so
+     * the source is self-contained: pasting it into any Mermaid 11+ renderer
+     * reproduces this diagram.
+     */
+    async viewSource(): Promise<void> {
+        if (this.currentText === undefined) {
+            vscode.window.showWarningMessage("No diagram source to show.");
+            return;
+        }
+        const doc = await vscode.workspace.openTextDocument({
+            content: this.currentText,
+            language: "markdown",
+        });
+        await vscode.window.showTextDocument(doc, {
+            viewColumn: vscode.ViewColumn.Beside,
+            preview: true,
+        });
     }
 
     /** Whether a panel is currently open. */
@@ -105,10 +229,18 @@ export class MermaidStateMachinePanel {
             return;
         }
         const defaultName = (this.currentName ?? "state-machine").replace(/[^\w.-]/g, "_");
+        // Default the save dialog next to the source .fpp/.fppi file, falling
+        // back to the (first) workspace folder, then a bare filename.
+        const baseFolder = this.sourceUri
+            ? vscode.Uri.joinPath(this.sourceUri, "..")
+            : vscode.workspace.workspaceFolders?.[0]?.uri;
+        const defaultUri = baseFolder
+            ? vscode.Uri.joinPath(baseFolder, `${defaultName}.svg`)
+            : vscode.Uri.file(`${defaultName}.svg`);
         const target = await vscode.window.showSaveDialog({
             saveLabel: "Export Diagram",
             filters: { "SVG image": ["svg"] },
-            defaultUri: vscode.Uri.file(`${defaultName}.svg`),
+            defaultUri,
         });
         if (!target) {
             return;
@@ -126,10 +258,107 @@ export class MermaidStateMachinePanel {
             return;
         }
         if (this.ready) {
-            void this.panel.webview.postMessage({ type: "render", text });
+            void this.panel.webview.postMessage({
+                type: "render",
+                text,
+                // The gear popover reflects the options embedded in the source
+                // (surfaced here via the Mermaid frontmatter).
+                layout: parseLayoutFromMermaid(text),
+            });
         } else {
             // Buffer until the webview signals ready.
             this.pending = text;
+        }
+    }
+
+    /**
+     * Apply a layout choice made from the webview's gear popover. The single
+     * source of truth is the FPP source, so this:
+     *   1. Optimistically rewrites the current Mermaid frontmatter and re-renders
+     *      (instant feedback, independent of language-server timing).
+     *   2. Writes the choice back to the `.fpp`/`.fppi` source as a
+     *      `@ diagram-layout ...` annotation (a workspace edit).
+     */
+    private async applyLayoutOption(key: unknown, value: unknown): Promise<void> {
+        if (
+            typeof key !== "string" ||
+            !LAYOUT_KEYS.includes(key as keyof LayoutOptions) ||
+            typeof value !== "string" ||
+            this.currentText === undefined
+        ) {
+            return;
+        }
+        const layout = parseLayoutFromMermaid(this.currentText);
+        layout[key as keyof LayoutOptions] = value;
+
+        // 1. Optimistic re-render from the rewritten frontmatter.
+        this.currentText = applyLayoutToMermaid(this.currentText, layout);
+        this.post(this.currentText);
+
+        // 2. Persist into the FPP source.
+        await this.writeLayoutAnnotation(layout);
+    }
+
+    /**
+     * Write `layout` into the state machine's `@ diagram-layout ...` pre-annotation
+     * in the source file (replacing an existing one, or inserting a new line just
+     * above the definition). Uses `fpp/diagramElements` to locate the definition.
+     */
+    private async writeLayoutAnnotation(layout: LayoutOptions): Promise<void> {
+        if (!this.sourceUri || this.currentName === undefined) {
+            return;
+        }
+        const client = this.clientProvider();
+        if (!client) {
+            return;
+        }
+
+        let elements: lsp_ext.DiagramElement[];
+        try {
+            elements = await client.sendRequest(lsp_ext.diagramElements, {
+                uri: this.sourceUri.toString(),
+            });
+        } catch (e) {
+            vscode.window.showErrorMessage(`Failed to locate state machine: ${e}`);
+            return;
+        }
+        const element = elements.find(
+            e => e.kind === "stateMachine" && e.name === this.currentName
+        );
+        if (!element) {
+            return;
+        }
+
+        const doc = await vscode.workspace.openTextDocument(this.sourceUri);
+        const defLine = element.range.start.line;
+        const indent = /^\s*/.exec(doc.lineAt(defLine).text)?.[0] ?? "";
+        const annotationLine = `${indent}@ ${layoutToAnnotation(layout)}`;
+
+        // Find an existing `@ diagram-layout` line among the contiguous annotation
+        // lines directly above the definition.
+        let existing = -1;
+        for (let i = defLine - 1; i >= 0; i--) {
+            const trimmed = doc.lineAt(i).text.trim();
+            if (!trimmed.startsWith("@")) {
+                break;
+            }
+            const body = trimmed.replace(/^@<?\s?/, "").trim();
+            if (body.startsWith("diagram-layout")) {
+                existing = i;
+                break;
+            }
+        }
+
+        const edit = new vscode.WorkspaceEdit();
+        if (existing >= 0) {
+            edit.replace(this.sourceUri, doc.lineAt(existing).range, annotationLine);
+        } else {
+            edit.insert(this.sourceUri, new vscode.Position(defLine, 0), `${annotationLine}\n`);
+        }
+        try {
+            await vscode.workspace.applyEdit(edit);
+        } catch (e) {
+            vscode.window.showErrorMessage(`Failed to write layout annotation: ${e}`);
         }
     }
 
@@ -148,28 +377,29 @@ export class MermaidStateMachinePanel {
         );
         panel.webview.html = this.html(panel.webview);
 
-        // Drive a context key so the fit/export toolbar buttons show only while
-        // this panel is the active one.
-        const setFocus = (focused: boolean) =>
-            void vscode.commands.executeCommand(
-                "setContext",
-                "fppStateMachineDiagram-focused",
-                focused
-            );
-        setFocus(panel.active);
-        panel.onDidChangeViewState(e => setFocus(e.webviewPanel.active));
+        // The fit/export toolbar buttons are gated in package.json on the
+        // built-in `activeWebviewPanelId == 'fppStateMachineDiagram'` context,
+        // which VS Code scopes to this panel's own title bar — so no manual
+        // focus context key is needed (a global one leaked the buttons onto
+        // other visible editors).
 
         panel.webview.onDidReceiveMessage(msg => {
             if (msg?.type === "ready") {
                 this.ready = true;
                 if (this.pending !== undefined) {
-                    void panel.webview.postMessage({ type: "render", text: this.pending });
+                    void panel.webview.postMessage({
+                        type: "render",
+                        text: this.pending,
+                        layout: parseLayoutFromMermaid(this.pending),
+                    });
                     this.pending = undefined;
                 }
             } else if (msg?.type === "error") {
                 console.error("Mermaid render error:", msg.message);
             } else if (msg?.type === "exportSvg") {
                 void this.saveSvg(msg.svg);
+            } else if (msg?.type === "setLayoutOption") {
+                void this.applyLayoutOption(msg.key, msg.value);
             }
         });
 
@@ -177,7 +407,6 @@ export class MermaidStateMachinePanel {
             this.panel = undefined;
             this.ready = false;
             this.pending = undefined;
-            setFocus(false);
         });
 
         this.panel = panel;

--- a/editors/code/src/diagram/mermaid-panel.ts
+++ b/editors/code/src/diagram/mermaid-panel.ts
@@ -89,14 +89,28 @@ function parseLayoutFromMermaid(text: string): LayoutOptions {
  * language-server round-trip.
  */
 function applyLayoutToMermaid(text: string, layout: LayoutOptions): string {
-    return text
+    let out = text
         .replace(/(^\s*layout:\s*)\S+/m, `$1${layout.engine}`)
-        .replace(/(^\s*direction\s+)\S+/m, `$1${layout.direction}`)
         .replace(/(nodePlacementStrategy:\s*)\S+/, `$1${layout.nodePlacement}`)
         .replace(/(cycleBreakingStrategy:\s*)\S+/, `$1${layout.cycleBreaking}`)
         .replace(/(considerModelOrder:\s*)\S+/, `$1${layout.considerModelOrder}`)
         .replace(/(nodeSpacing:\s*)\S+/, `$1${layout.nodeSpacing}`)
         .replace(/(rankSpacing:\s*)\S+/, `$1${layout.rankSpacing}`);
+
+    // Direction is applied by Mermaid from a `direction` statement in the diagram
+    // *body* (not from config), so the rendered text must carry it. Replace an
+    // existing statement, or insert one right after the `stateDiagram-v2` header
+    // if absent — the latter keeps the live view correct even against a language
+    // server that predates the `direction` annotation and so emits no such line.
+    if (/^\s*direction\s+\S+/m.test(out)) {
+        out = out.replace(/(^\s*direction\s+)\S+/m, `$1${layout.direction}`);
+    } else {
+        out = out.replace(
+            /^(\s*)(stateDiagram-v2.*)$/m,
+            `$1$2\n$1    direction ${layout.direction}`
+        );
+    }
+    return out;
 }
 
 /** The `diagram-layout` annotation *body* (without the `@ ` marker) for `layout`. */
@@ -120,6 +134,18 @@ export class MermaidStateMachinePanel {
     private sourceUri: vscode.Uri | undefined;
     /** The Mermaid source most recently rendered, for the "view source" action. */
     private currentText: string | undefined;
+    /**
+     * The authoritative current layout selection. Seeded from the server-generated
+     * source on each refresh, then mutated in place as the user changes options.
+     *
+     * This is the source of truth for the live view — NOT re-parsed out of
+     * `currentText` on each change. The server's Mermaid text only contains the
+     * frontmatter blocks relevant to its chosen engine (e.g. no `state:` spacing
+     * block under ELK), so parsing options back out of it would drop any option
+     * whose block is currently absent (notably spacing right after switching to
+     * dagre). Keeping the full selection here makes every option round-trip.
+     */
+    private currentLayout: LayoutOptions = { ...DEFAULT_LAYOUT };
     /** Whether the webview has signalled it is ready to receive diagrams. */
     private ready = false;
     /** Text awaiting a not-yet-ready webview. */
@@ -170,6 +196,11 @@ export class MermaidStateMachinePanel {
             return;
         }
         this.currentText = text;
+        // Seed the authoritative layout from the freshly generated source (which
+        // reflects what's persisted in the FPP annotation). Options whose block is
+        // absent for the current engine fall back to defaults here — that's fine,
+        // because the source is the persisted truth after a full round-trip.
+        this.currentLayout = parseLayoutFromMermaid(text);
         this.post(text);
     }
 
@@ -261,9 +292,10 @@ export class MermaidStateMachinePanel {
             void this.panel.webview.postMessage({
                 type: "render",
                 text,
-                // The gear popover reflects the options embedded in the source
-                // (surfaced here via the Mermaid frontmatter).
-                layout: parseLayoutFromMermaid(text),
+                // The gear popover reflects the authoritative current selection
+                // (not a re-parse of the text, which may omit engine-irrelevant
+                // blocks like spacing under ELK).
+                layout: this.currentLayout,
             });
         } else {
             // Buffer until the webview signals ready.
@@ -288,10 +320,14 @@ export class MermaidStateMachinePanel {
         ) {
             return;
         }
-        const layout = parseLayoutFromMermaid(this.currentText);
-        layout[key as keyof LayoutOptions] = value;
+        // Mutate the authoritative selection, not a re-parse of the text.
+        this.currentLayout = { ...this.currentLayout, [key]: value };
+        const layout = this.currentLayout;
 
-        // 1. Optimistic re-render from the rewritten frontmatter.
+        // 1. Optimistic re-render. `applyLayoutToMermaid` only rewrites blocks that
+        //    are present in the current text; the webview applies the full layout
+        //    (which we pass in `post`) via Mermaid site config regardless, so the
+        //    render reflects the change even if the block isn't in the text yet.
         this.currentText = applyLayoutToMermaid(this.currentText, layout);
         this.post(this.currentText);
 
@@ -390,7 +426,7 @@ export class MermaidStateMachinePanel {
                     void panel.webview.postMessage({
                         type: "render",
                         text: this.pending,
-                        layout: parseLayoutFromMermaid(this.pending),
+                        layout: this.currentLayout,
                     });
                     this.pending = undefined;
                 }

--- a/editors/code/webview-sm/css/sm.css
+++ b/editors/code/webview-sm/css/sm.css
@@ -36,3 +36,97 @@ html, body {
     white-space: pre-wrap;
     padding: 12px;
 }
+
+/* Gear button that toggles the layout settings popover. */
+.sm-gear {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    z-index: 10;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    border: 1px solid var(--vscode-widget-border, transparent);
+    border-radius: 4px;
+    color: var(--vscode-icon-foreground, var(--vscode-foreground));
+    background: var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background));
+    opacity: 0.75;
+}
+
+.sm-gear:hover {
+    opacity: 1;
+    background: var(--vscode-toolbar-hoverBackground, var(--vscode-button-secondaryHoverBackground));
+}
+
+/* Layout settings popover. Hidden until `.open` is toggled by the gear. */
+.sm-settings {
+    position: fixed;
+    top: 44px;
+    right: 10px;
+    z-index: 10;
+    display: none;
+    flex-direction: column;
+    gap: 10px;
+    width: 260px;
+    padding: 12px;
+    box-sizing: border-box;
+    border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border, transparent));
+    border-radius: 6px;
+    background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    color: var(--vscode-foreground);
+    box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.36));
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size, 13px);
+}
+
+.sm-settings.open {
+    display: flex;
+}
+
+.sm-settings-title {
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: var(--vscode-descriptionForeground);
+}
+
+.sm-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.sm-field-label {
+    color: var(--vscode-foreground);
+}
+
+.sm-field-select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 3px 6px;
+    color: var(--vscode-settings-dropdownForeground, var(--vscode-dropdown-foreground));
+    background: var(--vscode-settings-dropdownBackground, var(--vscode-dropdown-background));
+    border: 1px solid var(--vscode-settings-dropdownBorder, var(--vscode-dropdown-border, transparent));
+    border-radius: 4px;
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size, 13px);
+}
+
+.sm-field-select:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+/* Numeric inputs (node/rank spacing) prefer the text-input theme colors. */
+input.sm-field-select {
+    color: var(--vscode-settings-numberInputForeground, var(--vscode-input-foreground));
+    background: var(--vscode-settings-numberInputBackground, var(--vscode-input-background));
+    border-color: var(--vscode-settings-numberInputBorder, var(--vscode-input-border, transparent));
+}

--- a/editors/code/webview-sm/src/main.ts
+++ b/editors/code/webview-sm/src/main.ts
@@ -3,9 +3,11 @@
  * from the extension host into inline SVG, with pan/zoom and SVG export.
  *
  * The extension host owns the panel and posts messages:
- *   `{ type: 'render', text }` — render Mermaid source
- *   `{ type: 'fit' }`          — reset pan/zoom to fit
- *   `{ type: 'export' }`       — reply with `{ type: 'exportSvg', svg }`
+ *   `{ type: 'render', text, layout? }` — render Mermaid source (ELK layout is
+ *                                         embedded in the source frontmatter);
+ *                                         `layout` only syncs the gear dropdowns
+ *   `{ type: 'fit' }`                   — reset pan/zoom to fit
+ *   `{ type: 'export' }`                — reply with `{ type: 'exportSvg', svg }`
  *
  * Rendering is pure DOM manipulation (no `eval`), satisfying the webview CSP.
  */
@@ -33,6 +35,11 @@ function isDarkTheme(): boolean {
         || document.body.classList.contains('vscode-high-contrast');
 }
 
+// Initialize Mermaid once with the static options. The per-diagram layout
+// options (engine + ELK strategies) are applied separately, via `applyLayout`
+// before each render, because Mermaid's frontmatter sanitizer drops config keys
+// it does not recognize — so the FPP source stays the source of truth, but the
+// values reach Mermaid through its (un-sanitized, per-render) site config.
 mermaid.initialize({
     startOnLoad: false,
     // `strict` is the safest level and needs no HTML/eval; we only render text.
@@ -42,18 +49,297 @@ mermaid.initialize({
     // actions below) and keeps text crisp under the webview CSP.
     htmlLabels: false,
     theme: isDarkTheme() ? 'dark' : 'default',
-    // Use the ELK layout backend for hierarchical (composite) state layout.
+    // The layout engine defaults to ELK for hierarchical (composite) state
+    // layout; `applyLayout` overrides it per-render from the FPP source.
     layout: 'elk',
     elk: {
         // Draw containers around composite states and give edges room.
         mergeEdges: false,
-        nodePlacementStrategy: 'BRANDES_KOEPF',
     },
     state: {
         nodeSpacing: 60,
         rankSpacing: 60,
     },
 });
+
+// --- In-webview layout settings (gear popover) --------------------------------
+// A gear button opens a small panel of dropdowns reflecting the layout options
+// embedded in the FPP source. Changing one posts a `setLayoutOption` message;
+// the host writes it back into the `@ diagram-layout ...` source annotation (a
+// workspace edit) and re-renders — so the source stays the single source of
+// truth. Keys match the host's `LayoutOptions`.
+interface LayoutOptions {
+    /** The Mermaid layout backend: `elk` or `dagre`. */
+    engine: string;
+    /** Flow direction (both engines): `TB`, `BT`, `LR`, or `RL`. */
+    direction: string;
+    cycleBreaking: string;
+    considerModelOrder: string;
+    nodePlacement: string;
+    /** Node spacing in px, as a string (dagre only). */
+    nodeSpacing: string;
+    /** Rank spacing in px, as a string (dagre only). */
+    rankSpacing: string;
+}
+
+/** Defaults; must match `fpp_diagram`'s `SmLayout::default()`. */
+const DEFAULT_LAYOUT: LayoutOptions = {
+    engine: 'elk',
+    direction: 'TB',
+    cycleBreaking: 'MODEL_ORDER',
+    considerModelOrder: 'NODES_AND_EDGES',
+    nodePlacement: 'BRANDES_KOEPF',
+    nodeSpacing: '60',
+    rankSpacing: '60',
+};
+
+/**
+ * A control backed by one layout option. `key` matches `LayoutOptions`. A control
+ * is either a dropdown (`options` set) or a numeric input (`number` set).
+ */
+interface LayoutControl {
+    key: keyof LayoutOptions;
+    label: string;
+    /** Dropdown choices; mutually exclusive with `number`. */
+    options?: { value: string; label: string }[];
+    /** Numeric-input bounds (px); mutually exclusive with `options`. */
+    number?: { min: number; max: number; step: number };
+    /** Only meaningful for the ELK backend; hidden when the engine is `dagre`. */
+    elkOnly?: boolean;
+    /** Only meaningful for the dagre backend; hidden when the engine is `elk`. */
+    dagreOnly?: boolean;
+}
+
+const LAYOUT_CONTROLS: LayoutControl[] = [
+    {
+        key: 'engine',
+        label: 'Layout engine',
+        options: [
+            { value: 'elk', label: 'ELK (nested layout)' },
+            { value: 'dagre', label: 'Dagre (built-in)' },
+        ],
+    },
+    {
+        key: 'direction',
+        label: 'Direction',
+        options: [
+            { value: 'TB', label: 'Top to bottom' },
+            { value: 'BT', label: 'Bottom to top' },
+            { value: 'LR', label: 'Left to right' },
+            { value: 'RL', label: 'Right to left' },
+        ],
+    },
+    {
+        key: 'cycleBreaking',
+        label: 'Cycle breaking',
+        elkOnly: true,
+        options: [
+            { value: 'MODEL_ORDER', label: 'Source order (initial at top)' },
+            { value: 'GREEDY_MODEL_ORDER', label: 'Balanced (source order + compact)' },
+            { value: 'GREEDY', label: 'Compact (by topology)' },
+            { value: 'DEPTH_FIRST', label: 'Depth first' },
+        ],
+    },
+    {
+        key: 'considerModelOrder',
+        label: 'Follow source order',
+        elkOnly: true,
+        options: [
+            { value: 'NODES_AND_EDGES', label: 'Nodes and edges' },
+            { value: 'PREFER_EDGES', label: 'Prefer edges' },
+            { value: 'PREFER_NODES', label: 'Prefer nodes' },
+            { value: 'NONE', label: 'None (fewest crossings)' },
+        ],
+    },
+    {
+        key: 'nodePlacement',
+        label: 'Node placement',
+        elkOnly: true,
+        options: [
+            { value: 'BRANDES_KOEPF', label: 'Balanced (Brandes\u2013K\u00f6pf)' },
+            { value: 'NETWORK_SIMPLEX', label: 'Compact (network simplex)' },
+            { value: 'LINEAR_SEGMENTS', label: 'Straight chains' },
+            { value: 'SIMPLE', label: 'Simple' },
+        ],
+    },
+    {
+        key: 'nodeSpacing',
+        label: 'Node spacing (px)',
+        dagreOnly: true,
+        number: { min: 10, max: 300, step: 5 },
+    },
+    {
+        key: 'rankSpacing',
+        label: 'Rank spacing (px)',
+        dagreOnly: true,
+        number: { min: 10, max: 300, step: 5 },
+    },
+];
+
+/** The inputs (dropdowns/number fields), kept so `syncSettingsUi` can reflect the host's settings. */
+const settingsSelects = new Map<keyof LayoutOptions, HTMLSelectElement | HTMLInputElement>();
+
+/** Engine-specific fields, kept so they can be hidden for the other engine. */
+const elkOnlyFields: HTMLElement[] = [];
+const dagreOnlyFields: HTMLElement[] = [];
+
+/** Show/hide the engine-specific controls depending on the selected engine. */
+function updateControlVisibility(engine: string): void {
+    for (const field of elkOnlyFields) {
+        field.style.display = engine === 'elk' ? '' : 'none';
+    }
+    for (const field of dagreOnlyFields) {
+        field.style.display = engine === 'dagre' ? '' : 'none';
+    }
+}
+
+/** Build the gear button and settings popover and attach them to the page. */
+function buildSettingsUi(): void {
+    const gear = document.createElement('button');
+    gear.className = 'sm-gear';
+    gear.title = 'Diagram layout settings';
+    gear.setAttribute('aria-label', 'Diagram layout settings');
+    // Codicon-style gear glyph; falls back to a unicode gear.
+    gear.textContent = '\u2699';
+
+    const panel = document.createElement('div');
+    panel.className = 'sm-settings';
+
+    const title = document.createElement('div');
+    title.className = 'sm-settings-title';
+    title.textContent = 'Layout';
+    panel.appendChild(title);
+
+    for (const control of LAYOUT_CONTROLS) {
+        const field = document.createElement('label');
+        field.className = 'sm-field';
+
+        const name = document.createElement('span');
+        name.className = 'sm-field-label';
+        name.textContent = control.label;
+        field.appendChild(name);
+
+        // Post the changed value to the host, updating engine-driven visibility
+        // immediately for instant feedback (independent of the round-trip render).
+        const emit = (value: string) => {
+            if (control.key === 'engine') {
+                updateControlVisibility(value);
+            }
+            vscode.postMessage({ type: 'setLayoutOption', key: control.key, value });
+        };
+
+        let input: HTMLSelectElement | HTMLInputElement;
+        if (control.number) {
+            const num = document.createElement('input');
+            num.type = 'number';
+            num.className = 'sm-field-select';
+            num.min = String(control.number.min);
+            num.max = String(control.number.max);
+            num.step = String(control.number.step);
+            num.value = DEFAULT_LAYOUT[control.key];
+            // `change` fires on blur/Enter, not per keystroke, so we don't spam
+            // edits (and clamp to the allowed range before persisting).
+            num.addEventListener('change', () => {
+                const clamped = Math.min(
+                    control.number!.max,
+                    Math.max(control.number!.min, Number(num.value) || control.number!.min)
+                );
+                num.value = String(clamped);
+                emit(num.value);
+            });
+            input = num;
+        } else {
+            const select = document.createElement('select');
+            select.className = 'sm-field-select';
+            for (const opt of control.options ?? []) {
+                const option = document.createElement('option');
+                option.value = opt.value;
+                option.textContent = opt.label;
+                select.appendChild(option);
+            }
+            select.value = DEFAULT_LAYOUT[control.key];
+            select.addEventListener('change', () => emit(select.value));
+            input = select;
+        }
+
+        settingsSelects.set(control.key, input);
+        if (control.elkOnly) {
+            elkOnlyFields.push(field);
+        }
+        if (control.dagreOnly) {
+            dagreOnlyFields.push(field);
+        }
+        field.appendChild(input);
+        panel.appendChild(field);
+    }
+
+    updateControlVisibility(DEFAULT_LAYOUT.engine);
+
+    gear.addEventListener('click', e => {
+        e.stopPropagation();
+        panel.classList.toggle('open');
+    });
+    // Close the panel when clicking outside it.
+    document.addEventListener('mousedown', e => {
+        const target = e.target as Node;
+        if (panel.classList.contains('open') && !panel.contains(target) && target !== gear) {
+            panel.classList.remove('open');
+        }
+    });
+
+    document.body.appendChild(gear);
+    document.body.appendChild(panel);
+}
+
+/** Reflect the current (host-provided) layout in the dropdowns. */
+function syncSettingsUi(layout: LayoutOptions): void {
+    for (const [key, select] of settingsSelects) {
+        select.value = layout[key];
+    }
+    updateControlVisibility(layout.engine);
+}
+
+/**
+ * Push the layout options into Mermaid's *site config* before rendering.
+ *
+ * We cannot rely on the YAML frontmatter embedded in the diagram text: Mermaid's
+ * frontmatter sanitizer silently drops config keys it does not recognize (e.g.
+ * `elk.cycleBreakingStrategy` is not in its config schema), so a frontmatter-only
+ * option never takes effect. Site config is not sanitized that way and is re-read
+ * fresh on every `mermaid.render()`, so applying it here makes every option —
+ * including the layout engine — update live without reopening the panel.
+ *
+ * The flow direction is NOT set here: for state diagrams Mermaid reads it from a
+ * `direction` statement in the diagram body, which is already present in the text
+ * we render (kept in sync by the host), so rendering the text applies it.
+ */
+function applyLayout(layout: LayoutOptions): void {
+    // Spacing is only honored by the dagre backend (ELK computes its own), and
+    // arrives as a string; coerce to a number, falling back to the default when
+    // it isn't a positive number.
+    const spacing = (value: string): number => {
+        const n = Number(value);
+        return Number.isFinite(n) && n > 0 ? n : Number(DEFAULT_LAYOUT.nodeSpacing);
+    };
+    // The values are validated/enumerated on the FPP side and by the dropdowns,
+    // but arrive here as plain strings; Mermaid's config types are string-literal
+    // unions, so cast the whole options object to the expected parameter type.
+    mermaid.mermaidAPI.updateSiteConfig({
+        layout: layout.engine,
+        elk: {
+            mergeEdges: false,
+            nodePlacementStrategy: layout.nodePlacement,
+            cycleBreakingStrategy: layout.cycleBreaking,
+            considerModelOrder: layout.considerModelOrder,
+        },
+        state: {
+            nodeSpacing: spacing(layout.nodeSpacing),
+            rankSpacing: spacing(layout.rankSpacing),
+        },
+    } as Parameters<typeof mermaid.mermaidAPI.updateSiteConfig>[0]);
+}
+
+buildSettingsUi();
 
 const container = document.getElementById('container')!;
 
@@ -196,6 +482,14 @@ window.addEventListener('message', (event: MessageEvent) => {
     switch (msg.type) {
         case 'render':
             if (typeof msg.text === 'string') {
+                // Drive the layout from the `layout` object (via Mermaid site
+                // config), not the text frontmatter: frontmatter config keys that
+                // Mermaid does not recognize are silently dropped, so applying the
+                // options here is what makes every option — including the engine —
+                // take effect live. Fall back to defaults when absent.
+                const layout: LayoutOptions = { ...DEFAULT_LAYOUT, ...(msg.layout ?? {}) };
+                syncSettingsUi(layout);
+                applyLayout(layout);
                 void render(msg.text);
             }
             break;

--- a/fpp_diagram/src/ir.rs
+++ b/fpp_diagram/src/ir.rs
@@ -234,6 +234,13 @@ pub struct SmNode {
     pub entry_actions: Vec<String>,
     /// Exit actions (`exit do { ... }`), by name; empty if none.
     pub exit_actions: Vec<String>,
+    /// Internal transitions (`on signal [guard] do { ... }`), each pre-formatted
+    /// as `signal [guard] / a1 a2`. These react to a signal without changing
+    /// state, so — like entry/exit actions — they are shown *inside* the state
+    /// box rather than as a transition arrow (an arrow would wrongly imply the
+    /// state's exit/entry actions run). Empty if the state has none.
+    #[serde(default)]
+    pub internal_transitions: Vec<String>,
     /// Hover text with the full detail (entry/exit actions), or empty if none.
     /// Kept off the visible label to avoid a wide, noisy diagram.
     pub detail: String,

--- a/fpp_diagram/src/ir.rs
+++ b/fpp_diagram/src/ir.rs
@@ -269,6 +269,10 @@ pub struct StateMachineDiagram {
     pub name: String,
     pub nodes: Vec<SmNode>,
     pub edges: Vec<SmEdge>,
+    /// ELK layout options, parsed from the state machine's `diagram-layout`
+    /// source annotation (defaults when absent).
+    #[serde(default)]
+    pub layout: crate::layout::SmLayout,
 }
 
 impl SmNode {

--- a/fpp_diagram/src/layout.rs
+++ b/fpp_diagram/src/layout.rs
@@ -1,0 +1,331 @@
+//! Layout configuration for state machine diagrams.
+//!
+//! The configuration lives in the FPP source itself, as a pre-annotation on the
+//! `state machine` definition:
+//!
+//! ```fpp
+//! @ diagram-layout cycleBreaking=MODEL_ORDER considerModelOrder=NODES_AND_EDGES nodePlacement=BRANDES_KOEPF
+//! state machine M { ... }
+//! ```
+//!
+//! Keeping it in source (rather than an editor setting) means the layout travels
+//! with the model: it works offline, from the CLI, and is embedded into the
+//! generated Mermaid as YAML frontmatter so the diagram is self-contained.
+//!
+//! The values are the ELK option strings that Mermaid's ELK backend expects
+//! (`config.elk.*`). Parsing is lenient: unknown keys or values are ignored and
+//! fall back to the defaults, so hand-edited or future annotations never break
+//! diagram generation.
+
+/// Declare an ELK option enum with its default variant and the ELK string each
+/// variant maps to. Generates `elk()` (variant → ELK string), `parse()` (ELK
+/// string → variant), and a `Default` impl.
+macro_rules! layout_enum {
+    ($(#[$meta:meta])* $name:ident, default = $default:ident, { $($variant:ident => $elk:literal),+ $(,)? }) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum $name {
+            $($variant),+
+        }
+
+        impl $name {
+            /// The ELK option string for this value (as Mermaid's ELK backend
+            /// expects under `config.elk.*`).
+            pub fn elk(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $elk),+
+                }
+            }
+
+            /// Parse an ELK option string; returns `None` for unknown values.
+            pub fn parse(s: &str) -> Option<Self> {
+                match s {
+                    $($elk => Some(Self::$variant),)+
+                    _ => None,
+                }
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::$default
+            }
+        }
+    };
+}
+
+layout_enum!(
+    /// How ELK breaks cycles in the transition graph. `ModelOrder` reverses every
+    /// transition that runs backward in source order, keeping the initial state at
+    /// the top and the flow reading downward.
+    CycleBreaking,
+    default = ModelOrder,
+    {
+        ModelOrder => "MODEL_ORDER",
+        GreedyModelOrder => "GREEDY_MODEL_ORDER",
+        Greedy => "GREEDY",
+        DepthFirst => "DEPTH_FIRST",
+    }
+);
+
+layout_enum!(
+    /// How strongly ELK follows the source declaration order when positioning
+    /// nodes.
+    ConsiderModelOrder,
+    default = NodesAndEdges,
+    {
+        NodesAndEdges => "NODES_AND_EDGES",
+        PreferEdges => "PREFER_EDGES",
+        PreferNodes => "PREFER_NODES",
+        None => "NONE",
+    }
+);
+
+layout_enum!(
+    /// The ELK node-placement algorithm used within each layer.
+    NodePlacement,
+    default = BrandesKoepf,
+    {
+        BrandesKoepf => "BRANDES_KOEPF",
+        NetworkSimplex => "NETWORK_SIMPLEX",
+        LinearSegments => "LINEAR_SEGMENTS",
+        Simple => "SIMPLE",
+    }
+);
+
+layout_enum!(
+    /// The Mermaid layout backend that draws the diagram. `Elk` (the default)
+    /// handles nested composite states well and honors the ELK options below;
+    /// `Dagre` is Mermaid's built-in renderer (no plugin required) and ignores the
+    /// ELK-specific options.
+    LayoutEngine,
+    default = Elk,
+    {
+        Elk => "elk",
+        Dagre => "dagre",
+    }
+);
+
+layout_enum!(
+    /// The flow direction of the diagram (Mermaid `direction` statement). Applies
+    /// to both layout engines. `TopBottom` (the default) reads top-to-bottom.
+    Direction,
+    default = TopBottom,
+    {
+        TopBottom => "TB",
+        BottomTop => "BT",
+        LeftRight => "LR",
+        RightLeft => "RL",
+    }
+);
+
+/// Default node spacing (px) — the gap between sibling nodes. Matches the
+/// webview's initialize-time `state.nodeSpacing`.
+pub const DEFAULT_NODE_SPACING: u32 = 60;
+/// Default rank spacing (px) — the gap between layers/ranks. Matches the
+/// webview's initialize-time `state.rankSpacing`.
+pub const DEFAULT_RANK_SPACING: u32 = 60;
+
+/// The tag that identifies a layout annotation line (after the `@ ` marker is
+/// stripped by the lexer).
+pub const ANNOTATION_TAG: &str = "diagram-layout";
+
+/// Layout options for a state machine diagram, parsed from (and serialized back
+/// to) a `diagram-layout` source annotation.
+///
+/// `engine` and `direction` apply to both layout backends; the ELK strategies
+/// (`cycle_breaking`, `consider_model_order`, `node_placement`) apply only to the
+/// ELK backend, and the spacing values (`node_spacing`, `rank_spacing`) are read
+/// only by the `dagre` backend (ELK computes its own spacing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SmLayout {
+    /// The Mermaid layout backend (`elk` or `dagre`).
+    pub engine: LayoutEngine,
+    /// The diagram flow direction (both engines).
+    pub direction: Direction,
+    pub cycle_breaking: CycleBreaking,
+    pub consider_model_order: ConsiderModelOrder,
+    pub node_placement: NodePlacement,
+    /// Gap between sibling nodes, in px (dagre only).
+    pub node_spacing: u32,
+    /// Gap between layers/ranks, in px (dagre only).
+    pub rank_spacing: u32,
+}
+
+impl Default for SmLayout {
+    fn default() -> Self {
+        Self {
+            engine: LayoutEngine::default(),
+            direction: Direction::default(),
+            cycle_breaking: CycleBreaking::default(),
+            consider_model_order: ConsiderModelOrder::default(),
+            node_placement: NodePlacement::default(),
+            node_spacing: DEFAULT_NODE_SPACING,
+            rank_spacing: DEFAULT_RANK_SPACING,
+        }
+    }
+}
+
+impl SmLayout {
+    /// Parse layout options from a definition's pre-annotation lines (as stored
+    /// by the parser: the annotation text with the leading `@ ` marker removed).
+    ///
+    /// Recognizes a line of the form `diagram-layout key=value ...`. Later lines
+    /// and later keys win; unknown keys/values are ignored, leaving defaults.
+    pub fn from_annotations<S: AsRef<str>>(pre: &[S]) -> Self {
+        let mut layout = Self::default();
+        for line in pre {
+            let line = line.as_ref().trim();
+            let Some(rest) = line.strip_prefix(ANNOTATION_TAG) else {
+                continue;
+            };
+            // Require whitespace (or end) after the tag so `diagram-layouts` etc.
+            // don't match.
+            if rest.chars().next().is_some_and(|c| !c.is_whitespace()) {
+                continue;
+            }
+            for token in rest.split_whitespace() {
+                let Some((key, value)) = token.split_once('=') else {
+                    continue;
+                };
+                match key {
+                    "engine" => {
+                        if let Some(v) = LayoutEngine::parse(value) {
+                            layout.engine = v;
+                        }
+                    }
+                    "direction" => {
+                        if let Some(v) = Direction::parse(value) {
+                            layout.direction = v;
+                        }
+                    }
+                    "nodeSpacing" => {
+                        if let Ok(v) = value.parse::<u32>() {
+                            layout.node_spacing = v;
+                        }
+                    }
+                    "rankSpacing" => {
+                        if let Ok(v) = value.parse::<u32>() {
+                            layout.rank_spacing = v;
+                        }
+                    }
+                    "cycleBreaking" => {
+                        if let Some(v) = CycleBreaking::parse(value) {
+                            layout.cycle_breaking = v;
+                        }
+                    }
+                    "considerModelOrder" => {
+                        if let Some(v) = ConsiderModelOrder::parse(value) {
+                            layout.consider_model_order = v;
+                        }
+                    }
+                    "nodePlacement" => {
+                        if let Some(v) = NodePlacement::parse(value) {
+                            layout.node_placement = v;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        layout
+    }
+
+    /// Render the annotation *text* (without the leading `@ ` marker) that encodes
+    /// these options. Used by the editor to write the configuration back to the
+    /// FPP source.
+    pub fn to_annotation(&self) -> String {
+        format!(
+            "{ANNOTATION_TAG} engine={} direction={} cycleBreaking={} \
+             considerModelOrder={} nodePlacement={} nodeSpacing={} rankSpacing={}",
+            self.engine.elk(),
+            self.direction.elk(),
+            self.cycle_breaking.elk(),
+            self.consider_model_order.elk(),
+            self.node_placement.elk(),
+            self.node_spacing,
+            self.rank_spacing,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_source_order_friendly() {
+        let l = SmLayout::default();
+        assert_eq!(l.engine.elk(), "elk");
+        assert_eq!(l.direction.elk(), "TB");
+        assert_eq!(l.cycle_breaking.elk(), "MODEL_ORDER");
+        assert_eq!(l.consider_model_order.elk(), "NODES_AND_EDGES");
+        assert_eq!(l.node_placement.elk(), "BRANDES_KOEPF");
+        assert_eq!(l.node_spacing, DEFAULT_NODE_SPACING);
+        assert_eq!(l.rank_spacing, DEFAULT_RANK_SPACING);
+    }
+
+    #[test]
+    fn parses_engine() {
+        let pre = vec!["diagram-layout engine=dagre".to_string()];
+        assert_eq!(SmLayout::from_annotations(&pre).engine, LayoutEngine::Dagre);
+        // Unknown engine falls back to the default.
+        let pre = vec!["diagram-layout engine=bogus".to_string()];
+        assert_eq!(SmLayout::from_annotations(&pre).engine, LayoutEngine::Elk);
+    }
+
+    #[test]
+    fn parses_direction_and_spacing() {
+        let pre = vec!["diagram-layout direction=LR nodeSpacing=80 rankSpacing=100".to_string()];
+        let l = SmLayout::from_annotations(&pre);
+        assert_eq!(l.direction, Direction::LeftRight);
+        assert_eq!(l.node_spacing, 80);
+        assert_eq!(l.rank_spacing, 100);
+
+        // Unknown direction and non-numeric spacing fall back to defaults.
+        let pre = vec!["diagram-layout direction=DIAGONAL nodeSpacing=huge".to_string()];
+        let l = SmLayout::from_annotations(&pre);
+        assert_eq!(l.direction, Direction::TopBottom);
+        assert_eq!(l.node_spacing, DEFAULT_NODE_SPACING);
+    }
+
+    #[test]
+    fn parses_annotation_line() {
+        let pre = vec![
+            "some human doc".to_string(),
+            "diagram-layout cycleBreaking=GREEDY nodePlacement=NETWORK_SIMPLEX".to_string(),
+        ];
+        let l = SmLayout::from_annotations(&pre);
+        assert_eq!(l.cycle_breaking, CycleBreaking::Greedy);
+        assert_eq!(l.node_placement, NodePlacement::NetworkSimplex);
+        // Unspecified key keeps its default.
+        assert_eq!(l.consider_model_order, ConsiderModelOrder::NodesAndEdges);
+    }
+
+    #[test]
+    fn ignores_unknown_values_and_tags() {
+        let pre = vec![
+            "diagram-layouts cycleBreaking=GREEDY".to_string(), // wrong tag
+            "diagram-layout cycleBreaking=BOGUS considerModelOrder=NONE".to_string(),
+        ];
+        let l = SmLayout::from_annotations(&pre);
+        assert_eq!(l.cycle_breaking, CycleBreaking::ModelOrder); // bogus ignored
+        assert_eq!(l.consider_model_order, ConsiderModelOrder::None);
+    }
+
+    #[test]
+    fn round_trips_through_annotation() {
+        let l = SmLayout {
+            engine: LayoutEngine::Dagre,
+            direction: Direction::LeftRight,
+            cycle_breaking: CycleBreaking::GreedyModelOrder,
+            consider_model_order: ConsiderModelOrder::PreferEdges,
+            node_placement: NodePlacement::Simple,
+            node_spacing: 75,
+            rank_spacing: 90,
+        };
+        let parsed = SmLayout::from_annotations(&[l.to_annotation()]);
+        assert_eq!(l, parsed);
+    }
+}

--- a/fpp_diagram/src/lib.rs
+++ b/fpp_diagram/src/lib.rs
@@ -13,12 +13,14 @@
 //! pass.
 
 pub mod ir;
+pub mod layout;
 pub mod lower;
 pub mod lower_sm;
 pub mod mermaid;
 pub mod sprotty;
 
 pub use ir::{Diagram, DiagramKind, StateMachineDiagram, TransitionActionMode};
+pub use layout::SmLayout;
 pub use lower::LowerError;
 
 use fpp_analysis::Analysis;

--- a/fpp_diagram/src/lower_sm.rs
+++ b/fpp_diagram/src/lower_sm.rs
@@ -7,6 +7,7 @@
 //! the flattened leaf-state view.
 
 use crate::ir::{SmEdge, SmNode, SmNodeKind, StateMachineDiagram, TransitionActionMode};
+use crate::layout::SmLayout;
 use crate::lower::LowerError;
 use fpp_analysis::Analysis;
 use fpp_analysis::semantics::state_machine::transition_graph::{Arc as TgArc, Node as TgNode};
@@ -14,7 +15,7 @@ use fpp_analysis::semantics::state_machine::{
     State, StateMachine, StateMachineAnalysis, StateMachineSymbol, StateOrChoice,
 };
 use fpp_ast::{DoExpr, TransitionExpr, TransitionOrDo};
-use fpp_core::{Span, Spanned};
+use fpp_core::{Annotated, Span, Spanned};
 
 /// A source-order sort key for a span: `(file, byte offset)`. Ordering diagram
 /// elements by this makes the layout follow the order things appear in the FPP
@@ -86,10 +87,15 @@ pub fn lower_state_machine(
         edges.push(edge);
     }
 
+    // Layout options are read from the state machine definition's pre-annotation
+    // (`@ diagram-layout ...`), so the configuration lives in the FPP source.
+    let layout = SmLayout::from_annotations(&sm.node.pre_annotation());
+
     Ok(StateMachineDiagram {
         name: a.get_qualified_name(&sm.get_symbol()),
         nodes,
         edges,
+        layout,
     })
 }
 

--- a/fpp_diagram/src/lower_sm.rs
+++ b/fpp_diagram/src/lower_sm.rs
@@ -14,7 +14,7 @@ use fpp_analysis::semantics::state_machine::transition_graph::{Arc as TgArc, Nod
 use fpp_analysis::semantics::state_machine::{
     State, StateMachine, StateMachineAnalysis, StateMachineSymbol, StateOrChoice,
 };
-use fpp_ast::{DoExpr, TransitionExpr, TransitionOrDo};
+use fpp_ast::{DefState, DoExpr, StateMember, TransitionExpr, TransitionOrDo};
 use fpp_core::{Annotated, Span, Spanned};
 
 /// A source-order sort key for a span: `(file, byte offset)`. Ordering diagram
@@ -53,6 +53,7 @@ pub fn lower_state_machine(
             depth: 0,
             entry_actions: vec![],
             exit_actions: vec![],
+            internal_transitions: vec![],
             detail: String::new(),
         });
         edges.push(SmEdge {
@@ -141,7 +142,8 @@ fn soc_node(sma: &StateMachineAnalysis, soc: &StateOrChoice) -> SmNode {
                 .iter()
                 .map(|i| i.data.clone())
                 .collect();
-            let detail = state_detail(&label, &entry_actions, &exit_actions);
+            let internal_transitions = internal_transitions_of(def);
+            let detail = state_detail(&label, &entry_actions, &exit_actions, &internal_transitions);
             SmNode {
                 id,
                 label,
@@ -150,6 +152,7 @@ fn soc_node(sma: &StateMachineAnalysis, soc: &StateOrChoice) -> SmNode {
                 depth,
                 entry_actions,
                 exit_actions,
+                internal_transitions,
                 detail,
             }
         }
@@ -161,6 +164,7 @@ fn soc_node(sma: &StateMachineAnalysis, soc: &StateOrChoice) -> SmNode {
             depth,
             entry_actions: vec![],
             exit_actions: vec![],
+            internal_transitions: vec![],
             detail: String::new(),
         },
         // A `State` variant should always wrap a `State` symbol; fall back
@@ -173,6 +177,7 @@ fn soc_node(sma: &StateMachineAnalysis, soc: &StateOrChoice) -> SmNode {
             depth,
             entry_actions: vec![],
             exit_actions: vec![],
+            internal_transitions: vec![],
             detail: String::new(),
         },
     }
@@ -190,9 +195,10 @@ fn node_depth(sma: &StateMachineAnalysis, symbol: &StateMachineSymbol) -> u32 {
 }
 
 /// Build the hover-detail text for a state: its name plus any entry/exit action
-/// lists. Empty when the state has no actions (nothing extra to reveal).
-fn state_detail(name: &str, entry: &[String], exit: &[String]) -> String {
-    if entry.is_empty() && exit.is_empty() {
+/// lists and internal transitions. Empty when the state has nothing extra to
+/// reveal.
+fn state_detail(name: &str, entry: &[String], exit: &[String], internal: &[String]) -> String {
+    if entry.is_empty() && exit.is_empty() && internal.is_empty() {
         return String::new();
     }
     let mut lines = vec![name.to_string()];
@@ -202,7 +208,45 @@ fn state_detail(name: &str, entry: &[String], exit: &[String]) -> String {
     if !exit.is_empty() {
         lines.push(format!("exit / {}", exit.join(" ")));
     }
+    // Internal transitions (`on sig [guard] do { ... }`) react to a signal
+    // without leaving the state; each is already formatted `sig [guard] / a…`.
+    lines.extend(internal.iter().cloned());
     lines.join("\n")
+}
+
+/// Collect a state's internal transitions — `on signal [guard] do { ... }`
+/// specifiers, i.e. `SpecStateTransition`s whose body is a `do` block with no
+/// target state. Each is pre-formatted as `signal [guard] / a1 a2` (the guard
+/// and action clauses omitted when absent). These never enter the transition
+/// graph (they have no target arc), so they must be read directly from the
+/// state's AST members here.
+fn internal_transitions_of(def: &DefState) -> Vec<String> {
+    def.members
+        .iter()
+        .filter_map(|m| match m {
+            StateMember::SpecStateTransition(st) => match &st.transition_or_do {
+                TransitionOrDo::Do(d) => Some(format_internal_transition(st, d)),
+                // A `... enter Target` transition changes state; it is an arc in
+                // the transition graph and rendered as an edge, not here.
+                TransitionOrDo::Transition(_) => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+/// Format an internal transition as `signal [guard] / a1 a2`, dropping the
+/// `[guard]` and `/ actions` clauses when they are absent.
+fn format_internal_transition(st: &fpp_ast::SpecStateTransition, d: &DoExpr) -> String {
+    let mut s = st.signal.data.clone();
+    if let Some(guard) = &st.guard {
+        s.push_str(&format!(" [{}]", guard.data));
+    }
+    let actions = action_names(d);
+    if !actions.is_empty() {
+        s.push_str(&format!(" / {}", actions.join(" ")));
+    }
+    s
 }
 
 /// The source span of a transition-graph arc — the location of the `initial`,

--- a/fpp_diagram/src/mermaid.rs
+++ b/fpp_diagram/src/mermaid.rs
@@ -30,9 +30,11 @@ use std::fmt::Write;
 ///
 /// In [`TransitionActionMode::Uml`] each state's entry/exit actions are shown on
 /// the state itself: a leaf state uses inline description lines (`Id : entry /
-/// …`), and a composite (group) state uses a note (Mermaid rejects descriptions
-/// on group nodes). In [`TransitionActionMode::Flattened`] they are omitted from
-/// the nodes because they appear on the transition edges instead.
+/// …`), and a composite (group) state folds them into its label (Mermaid rejects
+/// descriptions on group nodes, and notes attached to a group node are hoisted
+/// out to the diagram's top level instead of staying nested). In
+/// [`TransitionActionMode::Flattened`] they are omitted from the nodes because
+/// they appear on the transition edges instead.
 pub fn state_machine_to_mermaid(
     diagram: &StateMachineDiagram,
     mode: TransitionActionMode,
@@ -49,7 +51,49 @@ pub fn state_machine_to_mermaid(
             .push(node);
     }
 
-    let mut out = String::from("stateDiagram-v2\n");
+    let mut out = String::new();
+
+    // Embed the layout options as Mermaid YAML frontmatter so the source is
+    // self-contained: any Mermaid 11+ renderer (with the ELK layout plugin)
+    // reproduces this diagram without external config. The options come from the
+    // FPP `diagram-layout` annotation via the IR.
+    let layout = &diagram.layout;
+    out.push_str("---\n");
+    out.push_str("config:\n");
+    let _ = writeln!(out, "  layout: {}", layout.engine.elk());
+    // The ELK options only apply to the ELK backend; `dagre` (Mermaid's built-in
+    // renderer) ignores them, so omit the block entirely for it. Conversely, the
+    // node/rank spacing (`state.*Spacing`) is honored only by `dagre` — ELK
+    // computes its own spacing — so emit that block only for `dagre`.
+    if layout.engine == crate::layout::LayoutEngine::Elk {
+        out.push_str("  elk:\n");
+        let _ = writeln!(
+            out,
+            "    nodePlacementStrategy: {}",
+            layout.node_placement.elk()
+        );
+        let _ = writeln!(
+            out,
+            "    cycleBreakingStrategy: {}",
+            layout.cycle_breaking.elk()
+        );
+        let _ = writeln!(
+            out,
+            "    considerModelOrder: {}",
+            layout.consider_model_order.elk()
+        );
+    } else {
+        out.push_str("  state:\n");
+        let _ = writeln!(out, "    nodeSpacing: {}", layout.node_spacing);
+        let _ = writeln!(out, "    rankSpacing: {}", layout.rank_spacing);
+    }
+    out.push_str("---\n");
+
+    out.push_str("stateDiagram-v2\n");
+
+    // The flow direction applies to both engines. For state diagrams Mermaid
+    // takes it from a `direction` statement in the body (not from config).
+    let _ = writeln!(out, "    direction {}", layout.direction.elk());
 
     // A style class so choices read as decision nodes but still show their name.
     // (A bare `<<choice>>` diamond renders without any visible label.)
@@ -137,17 +181,8 @@ fn emit_node(
             let kids = children_of.get(&Some(node.id.as_str()));
             let is_composite = kids.is_some_and(|k| !k.is_empty());
 
-            // Display the unqualified name regardless of the sanitized id.
-            let _ = writeln!(out, "{pad}state \"{}\" as {id}", escape_label(&node.label));
-
-            // In UML mode, show the state's entry/exit actions inside the state
-            // as description lines (`Id : entry / …`); in flattened mode these
-            // appear on the transition edges instead.
-            //
-            // Mermaid forbids a description line on a *composite* (group) state
-            // written outside its block ("Group nodes can only have label"), so
-            // for composite states the lines are emitted inside the `{ }` block
-            // below. Leaf states take their description lines here.
+            // In UML mode, show the state's entry/exit actions on the state; in
+            // flattened mode these appear on the transition edges instead.
             let action_descs: Vec<String> = if mode == TransitionActionMode::Uml {
                 let mut d = Vec::new();
                 if !node.entry_actions.is_empty() {
@@ -167,20 +202,28 @@ fn emit_node(
                 Vec::new()
             };
 
+            // Display label: the unqualified name. Mermaid forbids a description
+            // line on a *composite* (group) state ("Group nodes can only have
+            // label"), and a note attached to a group node is hoisted out of its
+            // parent to the diagram's top level (losing the nesting). So fold a
+            // composite state's entry/exit actions into its label instead — the
+            // label belongs to the (nested) box, so the actions stay in place.
+            // `<br/>` splits the label into stacked <tspan> lines (works under
+            // `securityLevel: strict` with `htmlLabels: false`).
+            let mut label = escape_label(&node.label);
+            if is_composite && !action_descs.is_empty() {
+                label.push_str("<br/>");
+                label.push_str(&action_descs.join("<br/>"));
+            }
+            let _ = writeln!(out, "{pad}state \"{label}\" as {id}");
+
             // A leaf state carries its entry/exit as inline description lines
-            // (`Id : entry / …`). A composite (group) state cannot have a
-            // description in Mermaid ("Group nodes can only have label"), so its
-            // actions are shown as a note attached to the state instead.
+            // (`Id : entry / …`). Composite states already carry them in the
+            // label above.
             if !is_composite {
                 for desc in &action_descs {
                     let _ = writeln!(out, "{pad}{id} : {desc}");
                 }
-            } else if !action_descs.is_empty() {
-                let _ = writeln!(out, "{pad}note right of {id}");
-                for desc in &action_descs {
-                    let _ = writeln!(out, "{pad}    {desc}");
-                }
-                let _ = writeln!(out, "{pad}end note");
             }
 
             if let Some(kids) = kids.filter(|k| !k.is_empty()) {

--- a/fpp_diagram/src/mermaid.rs
+++ b/fpp_diagram/src/mermaid.rs
@@ -35,6 +35,10 @@ use std::fmt::Write;
 /// out to the diagram's top level instead of staying nested). In
 /// [`TransitionActionMode::Flattened`] they are omitted from the nodes because
 /// they appear on the transition edges instead.
+///
+/// Internal transitions (`on signal [guard] do { … }`, which fire actions
+/// without leaving the state) are shown inside the state in *both* modes: they
+/// have no target arc, so there is no edge for flattened mode to fold them into.
 pub fn state_machine_to_mermaid(
     diagram: &StateMachineDiagram,
     mode: TransitionActionMode,
@@ -183,7 +187,7 @@ fn emit_node(
 
             // In UML mode, show the state's entry/exit actions on the state; in
             // flattened mode these appear on the transition edges instead.
-            let action_descs: Vec<String> = if mode == TransitionActionMode::Uml {
+            let mut action_descs: Vec<String> = if mode == TransitionActionMode::Uml {
                 let mut d = Vec::new();
                 if !node.entry_actions.is_empty() {
                     d.push(escape_label(&format!(
@@ -201,6 +205,13 @@ fn emit_node(
             } else {
                 Vec::new()
             };
+
+            // Internal transitions (`on signal [guard] do { ... }`) react to a
+            // signal without changing state, so — like entry/exit actions — they
+            // belong inside the state box, never as an arrow. They are shown in
+            // *both* action modes: there is no transition edge to fold them into,
+            // so flattened mode cannot move them elsewhere.
+            action_descs.extend(node.internal_transitions.iter().map(|t| escape_label(t)));
 
             // Display label: the unqualified name. Mermaid forbids a description
             // line on a *composite* (group) state ("Group nodes can only have

--- a/fpp_diagram/tests/lower_sm.rs
+++ b/fpp_diagram/tests/lower_sm.rs
@@ -331,6 +331,76 @@ state machine M {
     });
 }
 
+/// An internal transition (`on signal [guard] do { ... }`) reacts to a signal
+/// without changing state. It has no target arc, so it never appears as a
+/// transition edge; instead it is carried on the state (in `internal_transitions`
+/// and the hover `detail`) and rendered inside the state box by Mermaid — in
+/// both action modes, since there is no edge to fold it into.
+#[test]
+fn internal_transitions_render_inside_state() {
+    const SM_INTERNAL: &str = r#"
+state machine M {
+    guard g
+    signal s
+    signal t
+    action a1
+    action a2
+    initial enter IDLE
+    state IDLE {
+        on s do { a1 }
+        on t if g do { a1, a2 }
+        on s enter RUN
+    }
+    state RUN
+}
+"#;
+    for mode in [TransitionActionMode::Uml, TransitionActionMode::Flattened] {
+        with_analysis(SM_INTERNAL, |a| {
+            let sm = fpp_diagram::lower_state_machine(a, "M", mode)
+                .expect("state machine M should lower");
+            let idle = sm
+                .nodes
+                .iter()
+                .find(|n| n.id == "IDLE")
+                .expect("state IDLE");
+
+            // Both internal transitions are captured, formatted `sig [guard] / a…`.
+            assert_eq!(
+                idle.internal_transitions,
+                vec!["s / a1".to_string(), "t [g] / a1 a2".to_string()],
+                "mode {mode:?}"
+            );
+            // The hover detail lists them under the state name.
+            assert!(idle.detail.contains("s / a1"), "{}", idle.detail);
+            assert!(idle.detail.contains("t [g] / a1 a2"), "{}", idle.detail);
+
+            // The `on s enter RUN` external transition is still an edge; the two
+            // internal transitions are NOT edges.
+            assert!(
+                sm.edges.iter().any(|e| e.from == "IDLE" && e.to == "RUN"),
+                "external transition remains an edge"
+            );
+            assert!(
+                !sm.edges.iter().any(|e| e.from == "IDLE" && e.to == "IDLE"),
+                "internal transitions must not become self-edges"
+            );
+
+            // Mermaid renders them as inline description lines on the leaf state,
+            // in both action modes.
+            let mermaid =
+                fpp_diagram::lower_state_machine_to_mermaid(a, "M", mode).expect("mermaid");
+            assert!(
+                mermaid.contains("IDLE : s / a1"),
+                "mode {mode:?}:\n{mermaid}"
+            );
+            assert!(
+                mermaid.contains("IDLE : t [g] / a1 a2"),
+                "mode {mode:?}:\n{mermaid}"
+            );
+        });
+    }
+}
+
 /// A state's entry/exit actions go into `detail`, not the visible label.
 #[test]
 fn state_entry_actions_go_to_detail() {

--- a/fpp_diagram/tests/lower_sm.rs
+++ b/fpp_diagram/tests/lower_sm.rs
@@ -206,10 +206,11 @@ fn uml_mode_keeps_entry_exit_in_states() {
 }
 
 /// A *composite* state cannot carry a description in Mermaid ("Group nodes can
-/// only have label"), so its entry/exit actions must be shown as a note, not as
-/// an `Id : entry / …` description line, in UML mode.
+/// only have label"), and a note attached to a group node is hoisted out to the
+/// diagram's top level (losing the nesting). So its entry/exit actions are folded
+/// into the composite state's label instead, in UML mode.
 #[test]
-fn uml_mode_composite_state_uses_note_not_description() {
+fn uml_mode_composite_state_folds_actions_into_label() {
     const SM_COMPOSITE: &str = r#"
 state machine M {
     signal s
@@ -228,14 +229,21 @@ state machine M {
             fpp_diagram::lower_state_machine_to_mermaid(a, "M", TransitionActionMode::Uml)
                 .expect("mermaid");
 
-        // The composite state LOADING carries its entry action as a note.
-        assert!(mermaid.contains("note right of LOADING"), "\n{mermaid}");
-        assert!(mermaid.contains("entry / loadStart"), "\n{mermaid}");
+        // The composite state LOADING carries its entry action in its label,
+        // stacked under the name via `<br/>`, so it stays inside the box.
+        assert!(
+            mermaid.contains("state \"LOADING<br/>entry / loadStart\" as LOADING"),
+            "\n{mermaid}"
+        );
 
-        // It must NOT emit a `LOADING : …` description line (a statement whose
-        // left side is the state id), which Mermaid rejects for a group node.
-        // (Edges like `IDLE --> LOADING : s` are fine — they are not
+        // It must NOT use a note (Mermaid hoists group-node notes to the top
+        // level) or a `LOADING : …` description line (rejected for a group
+        // node). (Edges like `IDLE --> LOADING : s` are fine — they are not
         // descriptions of the LOADING node.)
+        assert!(
+            !mermaid.contains("note right of LOADING"),
+            "composite state must not use a note:\n{mermaid}"
+        );
         assert!(
             !mermaid
                 .lines()
@@ -408,6 +416,111 @@ fn missing_state_machine_is_an_error() {
     });
 }
 
+/// The `@ diagram-layout ...` annotation on a state machine drives the ELK
+/// options embedded in the Mermaid frontmatter, so configuration lives in the
+/// FPP source.
+#[test]
+fn layout_annotation_drives_mermaid_frontmatter() {
+    const SM_WITH_LAYOUT: &str = r#"
+@ diagram-layout cycleBreaking=GREEDY nodePlacement=NETWORK_SIMPLEX
+state machine M {
+    signal s
+    initial enter A
+    state A { on s enter B }
+    state B
+}
+"#;
+    with_analysis(SM_WITH_LAYOUT, |a| {
+        let sm =
+            fpp_diagram::lower_state_machine(a, "M", TransitionActionMode::Uml).expect("lowers");
+        assert_eq!(
+            sm.layout.cycle_breaking,
+            fpp_diagram::layout::CycleBreaking::Greedy
+        );
+
+        let mermaid =
+            fpp_diagram::lower_state_machine_to_mermaid(a, "M", TransitionActionMode::Uml)
+                .expect("mermaid");
+        assert!(
+            mermaid.contains("cycleBreakingStrategy: GREEDY"),
+            "\n{mermaid}"
+        );
+        assert!(
+            mermaid.contains("nodePlacementStrategy: NETWORK_SIMPLEX"),
+            "\n{mermaid}"
+        );
+        // Unspecified option keeps its default.
+        assert!(
+            mermaid.contains("considerModelOrder: NODES_AND_EDGES"),
+            "\n{mermaid}"
+        );
+        // Engine defaults to ELK.
+        assert!(mermaid.contains("layout: elk"), "\n{mermaid}");
+    });
+}
+
+/// Selecting the `dagre` engine changes the Mermaid `layout`, drops the ELK-only
+/// options (which `dagre` ignores), and emits the node/rank spacing block (which
+/// only `dagre` honors).
+#[test]
+fn dagre_engine_omits_elk_options() {
+    const SM_WITH_DAGRE: &str = r#"
+@ diagram-layout engine=dagre nodeSpacing=80 rankSpacing=100
+state machine M {
+    signal s
+    initial enter A
+    state A { on s enter B }
+    state B
+}
+"#;
+    with_analysis(SM_WITH_DAGRE, |a| {
+        let sm =
+            fpp_diagram::lower_state_machine(a, "M", TransitionActionMode::Uml).expect("lowers");
+        assert_eq!(sm.layout.engine, fpp_diagram::layout::LayoutEngine::Dagre);
+
+        let mermaid =
+            fpp_diagram::lower_state_machine_to_mermaid(a, "M", TransitionActionMode::Uml)
+                .expect("mermaid");
+        assert!(mermaid.contains("layout: dagre"), "\n{mermaid}");
+        // The ELK option block is omitted for the dagre backend.
+        assert!(!mermaid.contains("elk:"), "\n{mermaid}");
+        assert!(!mermaid.contains("cycleBreakingStrategy"), "\n{mermaid}");
+        // The spacing block is emitted for the dagre backend.
+        assert!(mermaid.contains("nodeSpacing: 80"), "\n{mermaid}");
+        assert!(mermaid.contains("rankSpacing: 100"), "\n{mermaid}");
+    });
+}
+
+/// The flow direction applies to both engines and is emitted as a `direction`
+/// statement in the diagram body. The spacing block is ELK-suppressed.
+#[test]
+fn direction_is_emitted_for_both_engines() {
+    const SM_LR: &str = r#"
+@ diagram-layout direction=LR
+state machine M {
+    signal s
+    initial enter A
+    state A { on s enter B }
+    state B
+}
+"#;
+    with_analysis(SM_LR, |a| {
+        let sm =
+            fpp_diagram::lower_state_machine(a, "M", TransitionActionMode::Uml).expect("lowers");
+        assert_eq!(
+            sm.layout.direction,
+            fpp_diagram::layout::Direction::LeftRight
+        );
+
+        let mermaid =
+            fpp_diagram::lower_state_machine_to_mermaid(a, "M", TransitionActionMode::Uml)
+                .expect("mermaid");
+        assert!(mermaid.contains("direction LR"), "\n{mermaid}");
+        // Default engine is ELK, so the dagre-only spacing block is absent.
+        assert!(!mermaid.contains("nodeSpacing:"), "\n{mermaid}");
+    });
+}
+
 #[test]
 fn generates_mermaid_state_diagram() {
     with_analysis(SM, |a| {
@@ -415,8 +528,14 @@ fn generates_mermaid_state_diagram() {
             fpp_diagram::lower_state_machine_to_mermaid(a, "M", TransitionActionMode::Uml)
                 .expect("state machine M should generate mermaid");
 
-        // Diagram header.
-        assert!(mermaid.starts_with("stateDiagram-v2\n"), "\n{mermaid}");
+        // YAML frontmatter embeds the layout config, then the diagram header.
+        assert!(mermaid.starts_with("---\n"), "\n{mermaid}");
+        assert!(mermaid.contains("layout: elk"), "\n{mermaid}");
+        assert!(
+            mermaid.contains("cycleBreakingStrategy: MODEL_ORDER"),
+            "\n{mermaid}"
+        );
+        assert!(mermaid.contains("\nstateDiagram-v2\n"), "\n{mermaid}");
 
         // The SM-level initial transition into S.
         assert!(mermaid.contains("[*] --> S"), "\n{mermaid}");
@@ -435,8 +554,13 @@ fn generates_mermaid_state_diagram() {
         assert!(mermaid.contains("S_C --> S1 : [g]"), "\n{mermaid}");
         assert!(mermaid.contains("S_C --> S2 : [!g]"), "\n{mermaid}");
 
-        // Display label for a state preserves its unqualified name.
-        assert!(mermaid.contains("state \"S\" as S"), "\n{mermaid}");
+        // Display label for a state preserves its unqualified name. S is a
+        // composite state with an entry action, so its actions are folded into
+        // the label (stacked under the name via `<br/>`).
+        assert!(
+            mermaid.contains("state \"S<br/>entry / onEnterS\" as S"),
+            "\n{mermaid}"
+        );
     });
 }
 

--- a/fpp_lsp_parser/src/grammar.rs
+++ b/fpp_lsp_parser/src/grammar.rs
@@ -197,9 +197,8 @@ fn formal_param(p: &mut Parser) {
 }
 
 fn format_(p: &mut Parser) {
-    assert!(p.at(FORMAT_KW));
     let m = p.start();
-    p.bump(FORMAT_KW);
+    p.expect(FORMAT_KW);
     p.expect(LITERAL_STRING);
     m.complete(p, FORMAT);
 }

--- a/fpp_lsp_server/Cargo.toml
+++ b/fpp_lsp_server/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.41"
 anyhow = "1.0.100"
 crossbeam-channel = "0.5.15"
 tracing-subscriber = { version =  "0.3.22", features = ["chrono", "env-filter"] }
-url = "2"
+percent-encoding = "2"
 ignore = "0.4"
 clap = { version = "4.5.60", features = ["derive"] }
 

--- a/fpp_lsp_server/src/analysis.rs
+++ b/fpp_lsp_server/src/analysis.rs
@@ -13,7 +13,6 @@ use std::fmt::{Display, Formatter};
 use std::mem;
 use std::str::FromStr;
 use std::time::Instant;
-use url::Url;
 
 #[derive(Debug)]
 pub enum Task {
@@ -265,7 +264,6 @@ impl GlobalState {
                     now.elapsed().as_secs_f64()
                 );
                 self.task(Task::Analysis);
-                self.send_request::<lsp_types::request::SemanticTokensRefresh>((), |_, _| {});
                 progress.finish(None);
             }
             Task::LoadFullWorkspace => {
@@ -296,17 +294,17 @@ impl GlobalState {
                                 if path.is_file()
                                     && path.extension().is_some_and(|ext| OsStr::new("fpp") == ext)
                                 {
-                                    match Url::from_file_path(path) {
-                                        Ok(url) => match Uri::from_str(url.as_str()) {
+                                    match crate::uri::from_file_path(path) {
+                                        Ok(uri_str) => match Uri::from_str(&uri_str) {
                                             Ok(uri) => {
                                                 files.push(uri);
                                             }
                                             Err(err) => {
-                                                tracing::warn!(context = "load full workspace", err = ?err, "failed to convert Url to Uri");
+                                                tracing::warn!(context = "load full workspace", err = ?err, "failed to convert file URI into Uri");
                                             }
                                         },
-                                        Err(err) => {
-                                            tracing::warn!(context = "load full workspace", err = ?err, "convert file path into url");
+                                        Err(()) => {
+                                            tracing::warn!(context = "load full workspace", path = ?path, "convert file path into URI");
                                         }
                                     }
                                 }
@@ -360,7 +358,6 @@ impl GlobalState {
 
                 self.cache = cache;
                 self.task(Task::Analysis);
-                self.send_request::<lsp_types::request::SemanticTokensRefresh>((), |_, _| {});
             }
             Task::Response(response) => self.respond(response),
             Task::Update(uri) => {
@@ -489,6 +486,14 @@ impl GlobalState {
                 // so a pull-based client could otherwise read the store mid-window and
                 // show stale results; pushing sends the authoritative set directly.
                 self.publish_diagnostics();
+
+                // Semantic highlights are pull-based and resolve colors against
+                // `self.analysis`. Edits refresh that snapshot only here, after the
+                // debounce, so the tokens the client pulled mid-edit were computed
+                // against the stale pre-edit analysis. Ask the client to re-pull now
+                // that the authoritative snapshot is in place, otherwise stale
+                // highlights persist until an unrelated event triggers another pull.
+                self.send_request::<lsp_types::request::SemanticTokensRefresh>((), |_, _| {});
             }
         }
     }

--- a/fpp_lsp_server/src/analysis.rs
+++ b/fpp_lsp_server/src/analysis.rs
@@ -90,15 +90,46 @@ impl GlobalState {
         })
     }
 
-    /// Ask the client to re-pull all document diagnostics.
+    /// Push the current diagnostic set to the client for every affected URI.
     ///
-    /// Diagnostics are pull-based, so after analysis updates the diagnostic store
-    /// asynchronously the client has no way of knowing the results are stale unless
-    /// we explicitly request a refresh.
-    fn refresh_diagnostics(&mut self) {
-        if self.capabilities.diagnostics_refresh() {
-            self.send_request::<lsp_types::request::WorkspaceDiagnosticRefresh>((), |_, _| {});
+    /// Diagnostics are push-based: rather than let the client pull (which could
+    /// race the debounced analysis and read a stale store), we send the
+    /// authoritative set ourselves once analysis finishes. Any URI that had
+    /// diagnostics on the previous push but is now clean receives an empty set so
+    /// the editor clears it.
+    fn publish_diagnostics(&mut self) {
+        let current = self.diagnostics.all();
+
+        // Clear any URI that had diagnostics last time but no longer does.
+        for uri in &self.published_uris {
+            if !current.contains_key(uri)
+                && let Ok(parsed) = Uri::from_str(uri)
+            {
+                self.send_notification::<lsp_types::notification::PublishDiagnostics>(
+                    lsp_types::PublishDiagnosticsParams {
+                        uri: parsed,
+                        diagnostics: Vec::new(),
+                        version: None,
+                    },
+                );
+            }
         }
+
+        let mut published = FxHashSet::default();
+        for (uri, diagnostics) in current {
+            if let Ok(parsed) = Uri::from_str(&uri) {
+                self.send_notification::<lsp_types::notification::PublishDiagnostics>(
+                    lsp_types::PublishDiagnosticsParams {
+                        uri: parsed,
+                        diagnostics,
+                        version: None,
+                    },
+                );
+                published.insert(uri);
+            }
+        }
+
+        self.published_uris = published;
     }
 
     pub fn parent_file(&self, file: SourceFile) -> SourceFile {
@@ -392,7 +423,11 @@ impl GlobalState {
 
                 let _ = mem::replace(&mut self.context, ctx);
                 self.cache.insert(new_cache.file, Arc::new(new_cache));
-                self.task(Task::Analysis);
+
+                // Don't run the expensive full-workspace analysis eagerly. Mark it
+                // dirty and let the main loop coalesce a burst of edits into a single
+                // debounced `Task::Analysis` once typing settles.
+                self.analysis_dirty = true;
             }
             Task::Analysis => {
                 // Clear all analysis diagnostics
@@ -450,9 +485,10 @@ impl GlobalState {
                 self.files = files;
                 self.analysis = Arc::new(analysis);
 
-                // The diagnostic store has been updated asynchronously; tell the client to
-                // re-pull diagnostics so it doesn't keep showing stale results.
-                self.refresh_diagnostics();
+                // Push the fresh diagnostic set to the client. Analysis is debounced,
+                // so a pull-based client could otherwise read the store mid-window and
+                // show stale results; pushing sends the authoritative set directly.
+                self.publish_diagnostics();
             }
         }
     }

--- a/fpp_lsp_server/src/config.rs
+++ b/fpp_lsp_server/src/config.rs
@@ -19,7 +19,6 @@ use lsp_types::{Uri, WorkspaceFolder};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use url::Url;
 
 /// Name of the project configuration file, searched for at each workspace root.
 pub const CONFIG_FILE_NAME: &str = ".fpp-lsp";
@@ -188,8 +187,8 @@ fn default_build_cache(dir: &Path) -> String {
 /// Build a file `Uri` for a locs path relative to `base_dir`.
 fn locs_uri(base_dir: &Path, relative: impl AsRef<Path>) -> Option<Uri> {
     let path = base_dir.join(relative);
-    let url = Url::from_file_path(&path).ok()?;
-    Uri::from_str(url.as_str()).ok()
+    let uri = crate::uri::from_file_path(&path).ok()?;
+    Uri::from_str(&uri).ok()
 }
 
 /// Search the given workspace folders for a `.fpp-lsp` file and resolve it into a
@@ -224,9 +223,7 @@ pub fn discover(workspace_folders: Option<&[WorkspaceFolder]>) -> Workspace {
 
 /// Convert a workspace folder `Uri` into a filesystem path.
 fn folder_path(folder: &WorkspaceFolder) -> Option<PathBuf> {
-    Url::from_str(folder.uri.as_str())
-        .ok()
-        .and_then(|url| url.to_file_path().ok())
+    crate::uri::to_file_path(folder.uri.as_str())
 }
 
 #[cfg(test)]

--- a/fpp_lsp_server/src/diagnostics.rs
+++ b/fpp_lsp_server/src/diagnostics.rs
@@ -50,6 +50,22 @@ impl LspDiagnosticsEmitter {
         self.0.lock().unwrap().get(uri)
     }
 
+    /// Snapshot of every URI's diagnostics. Used to push diagnostics to the client
+    /// after analysis so it never has to pull (and never sees a stale window).
+    pub fn all(&self) -> FxHashMap<String, Vec<Diagnostic>> {
+        let state = self.0.lock().unwrap();
+        state
+            .diagnostics
+            .iter()
+            .map(|(uri, diagnostics)| {
+                (
+                    uri.clone(),
+                    diagnostics.iter().map(|d| d.diagnostic.clone()).collect(),
+                )
+            })
+            .collect()
+    }
+
     /// Start tracking all diagnostics
     pub fn start_garbage_collection(&self) {
         let mut state = self.0.lock().unwrap();

--- a/fpp_lsp_server/src/global_state.rs
+++ b/fpp_lsp_server/src/global_state.rs
@@ -9,10 +9,17 @@ use lsp_server::RequestId;
 use lsp_types::{ProgressToken, SemanticTokens, Uri, WorkspaceFolder};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 pub(crate) type ReqHandler = fn(&mut GlobalState, lsp_server::Response);
 type ReqQueue = lsp_server::ReqQueue<(String, Instant), ReqHandler>;
+
+/// How long the main loop waits after the last edit-driven change before running
+/// semantic analysis. A burst of edits resets this window (every task/message
+/// resets it), so we run analysis once—when typing settles—instead of once per
+/// keystroke. Analysis re-checks every cached translation unit and is the
+/// dominant cost of an edit, so coalescing it keeps the server responsive.
+const ANALYSIS_DEBOUNCE: Duration = Duration::from_millis(150);
 
 #[derive(Debug)]
 pub struct TranslationUnitCache {
@@ -58,6 +65,14 @@ pub struct GlobalState {
     /// Computed compiler analysis
     pub(crate) analysis: Arc<Analysis>,
     pub(crate) analysis_diagnostics: FxHashSet<usize>,
+    /// Set when a cached translation unit has been reprocessed and the current
+    /// `analysis` snapshot is stale. The main loop coalesces these into a single
+    /// debounced `Task::Analysis` so a burst of edits triggers analysis only once.
+    pub(crate) analysis_dirty: bool,
+    /// URIs for which we last pushed a non-empty diagnostic set. Tracked so the next
+    /// push can send an empty set to any URI that has since become clean, clearing
+    /// stale diagnostics in the editor.
+    pub(crate) published_uris: FxHashSet<String>,
 
     pub(crate) capabilities: Arc<lsp::capabilities::ClientCapabilities>,
 
@@ -89,6 +104,8 @@ impl GlobalState {
             files: Default::default(),
             analysis: Arc::new(Analysis::new()),
             analysis_diagnostics: Default::default(),
+            analysis_dirty: false,
+            published_uris: Default::default(),
             capabilities: Arc::new(capabilities),
             semantic_tokens: Default::default(),
         }
@@ -121,7 +138,6 @@ impl GlobalState {
         self.send(request.into());
     }
 
-    #[allow(dead_code)]
     pub(crate) fn send_notification<N: lsp_types::notification::Notification>(
         &self,
         params: N::Params,
@@ -206,6 +222,15 @@ impl GlobalState {
 
     fn main_loop(&mut self, receiver: Receiver<lsp_server::Message>) {
         while !self.shutdown_requested {
+            // Arm the debounce timer only while analysis is pending. It is recreated
+            // on every iteration, so any task or incoming message resets the window;
+            // analysis fires once the server has been idle for `ANALYSIS_DEBOUNCE`.
+            let analysis_timer = if self.analysis_dirty {
+                crossbeam_channel::after(ANALYSIS_DEBOUNCE)
+            } else {
+                crossbeam_channel::never()
+            };
+
             crossbeam_channel::select_biased! {
                 recv(self.task_rx) -> msg => {
                     if let Ok(msg) = msg {
@@ -222,6 +247,11 @@ impl GlobalState {
                     if let Ok(msg) = msg {
                         self.on_message(Instant::now(), msg)
                     }
+                }
+                recv(analysis_timer) -> _ => {
+                    // Typing has settled: run the coalesced analysis exactly once.
+                    self.analysis_dirty = false;
+                    self.on_task(Task::Analysis);
                 }
             }
         }

--- a/fpp_lsp_server/src/handlers.rs
+++ b/fpp_lsp_server/src/handlers.rs
@@ -8,7 +8,7 @@ use crate::util::{
     completion_items_for_sm_state, completion_items_in_name_group, hover_for_node,
     hover_for_port_instance, hover_for_sm_symbol, hover_for_symbol, node_to_location,
     nodes_at_offset, port_instance_at_position, port_match_at_position, position_to_offset,
-    sm_symbol_at_position, symbol_at_position, symbol_to_completion_item,
+    sm_def_at_position, sm_symbol_at_position, symbol_at_position, symbol_to_completion_item,
 };
 use anyhow::Result;
 use fpp_analysis::semantics::{NameGroup, SymbolInterface};
@@ -599,6 +599,24 @@ pub fn handle_hover(state: &GlobalState, request: HoverParams) -> Result<Option<
     // Uses inside a state machine resolve via the state machine's own use-def
     // map, not the global one; resolve them before the generic lookup.
     if let Some((node, state_machine, sm_symbol)) = sm_symbol_at_position(
+        state,
+        &request.text_document_position_params.text_document.uri,
+        offset,
+    ) {
+        return Ok(Some(hover_for_sm_symbol(
+            state,
+            node,
+            state_machine,
+            &sm_symbol,
+        )));
+    }
+
+    // State machine member *definitions* (actions, guards, signals, states,
+    // choices) are absent from the global symbol_map — they live only in their
+    // state machine's analysis. Resolve a hover on such a definition name here
+    // so it shows the member's own info; otherwise it would fall through to the
+    // enclosing state machine below and show the parent state machine instead.
+    if let Some((node, state_machine, sm_symbol)) = sm_def_at_position(
         state,
         &request.text_document_position_params.text_document.uri,
         offset,
@@ -1289,4 +1307,128 @@ pub fn handle_range_formatting(
         range,
         new_text: text,
     }]))
+}
+
+#[cfg(test)]
+mod hover_tests {
+    use super::*;
+    use crate::global_state::GlobalState;
+    use lsp_types::{
+        HoverContents, MarkupContent, TextDocumentIdentifier, TextDocumentPositionParams,
+        WorkDoneProgressParams, WorkspaceFolder,
+    };
+    use std::path::{Path, PathBuf};
+
+    /// A unique temp dir per test (no `tempfile` dependency), mirroring the
+    /// helper used in `config::tests`.
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("fpp-lsp-hover-test-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// The `(line, character)` position (0-based) of the first occurrence of
+    /// `needle` in `src`.
+    fn position_of(src: &str, needle: &str) -> Position {
+        let byte = src.find(needle).expect("needle present in source");
+        let prefix = &src[..byte];
+        let line = prefix.matches('\n').count() as u32;
+        let col = prefix.len() as u32 - prefix.rfind('\n').map_or(0, |i| i as u32 + 1);
+        Position {
+            line,
+            character: col,
+        }
+    }
+
+    /// Build a workspace-indexed `GlobalState` for `src` written to `<dir>/m.fpp`,
+    /// returning the state and the file URI. The full workspace-scan pipeline runs
+    /// so the state machine analysis is populated exactly as at runtime.
+    fn state_for(dir: &Path, src: &str) -> (GlobalState, Uri) {
+        std::fs::write(dir.join(".fpp-lsp"), "scanWorkspace: true\n").unwrap();
+        std::fs::write(dir.join("m.fpp"), src).unwrap();
+
+        let root_uri = Uri::from_str(&crate::uri::from_file_path(dir).unwrap()).unwrap();
+        let file_uri =
+            Uri::from_str(&crate::uri::from_file_path(dir.join("m.fpp")).unwrap()).unwrap();
+
+        let (sender, _receiver) = crossbeam_channel::unbounded();
+        let workspace_folders = Some(vec![WorkspaceFolder {
+            uri: root_uri,
+            name: "test".to_string(),
+        }]);
+        let mut state = GlobalState::new(workspace_folders, sender, Default::default());
+
+        // Drive the real indexing pipeline: discover the config, scan+parse the
+        // workspace, then run semantic analysis.
+        state.on_task(Task::ReloadWorkspace);
+        state.on_task(Task::LoadFullWorkspace);
+        state.on_task(Task::Analysis);
+
+        (state, file_uri)
+    }
+
+    fn hover_at(state: &GlobalState, uri: &Uri, position: Position) -> String {
+        let hover = handle_hover(
+            state,
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri: uri.clone() },
+                    position,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("hover ok")
+        .expect("hover present");
+        match hover.contents {
+            HoverContents::Markup(MarkupContent { value, .. }) => value,
+            other => panic!("expected markup hover, got {other:?}"),
+        }
+    }
+
+    const SM_SRC: &str = "\
+module M {
+  state machine SM {
+    action myAction
+    guard myGuard
+    signal mySignal
+    initial enter Top
+    state Top {
+      choice Pick { if myGuard enter Top else enter Top }
+    }
+  }
+}
+";
+
+    /// Hovering the name of a state machine member *definition* shows that
+    /// member's own info (qualified under the state machine), not the enclosing
+    /// state machine's. Regression test for the definition-name hover falling
+    /// through to the parent `DefStateMachine`.
+    #[test]
+    fn hover_on_sm_member_definitions() {
+        let dir = temp_dir("member-defs");
+        let (state, uri) = state_for(&dir, SM_SRC);
+
+        for (needle, expected) in [
+            ("myAction", "(Action) SM.myAction"),
+            ("myGuard", "(Guard) SM.myGuard"),
+            ("mySignal", "(Signal) SM.mySignal"),
+            ("Top", "(State) SM.Top"),
+            ("Pick", "(Choice) SM.Top.Pick"),
+        ] {
+            let value = hover_at(&state, &uri, position_of(SM_SRC, needle));
+            assert!(
+                value.contains(expected),
+                "hover on `{needle}` should contain `{expected}`, got:\n{value}"
+            );
+            assert!(
+                !value.contains("(State Machine)"),
+                "hover on `{needle}` should not show the parent state machine, got:\n{value}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/fpp_lsp_server/src/lsp/capabilities.rs
+++ b/fpp_lsp_server/src/lsp/capabilities.rs
@@ -94,14 +94,12 @@ pub fn server_capabilities(caps: &ClientCapabilities) -> ServerCapabilities {
             }
             .into(),
         ),
-        diagnostic_provider: Some(lsp_types::DiagnosticServerCapabilities::Options(
-            lsp_types::DiagnosticOptions {
-                identifier: Some("fpp".to_owned()),
-                inter_file_dependencies: true,
-                workspace_diagnostics: false,
-                work_done_progress_options: Default::default(),
-            },
-        )),
+        // Diagnostics are pushed (textDocument/publishDiagnostics) rather than pulled.
+        // Analysis is debounced, so a pull-based client could read the diagnostic
+        // store mid-debounce and show stale results; pushing lets the server send the
+        // authoritative set once analysis settles. Leaving `diagnostic_provider` unset
+        // makes vscode-languageclient fall back to push mode.
+        diagnostic_provider: None,
         definition_provider: Some(OneOf::Left(true)),
         hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
         references_provider: Some(OneOf::Left(true)),
@@ -438,17 +436,19 @@ impl ClientCapabilities {
     //     .unwrap_or_default()
     // }
 
-    pub fn diagnostics_refresh(&self) -> bool {
-        (|| -> _ {
-            self.0
-                .workspace
-                .as_ref()?
-                .diagnostic
-                .as_ref()?
-                .refresh_support
-        })()
-        .unwrap_or_default()
-    }
+    // Diagnostics are now pushed, not pulled, so the client's pull-refresh support
+    // is no longer consulted. Kept for reference in case pull mode returns.
+    // pub fn diagnostics_refresh(&self) -> bool {
+    //     (|| -> _ {
+    //         self.0
+    //             .workspace
+    //             .as_ref()?
+    //             .diagnostic
+    //             .as_ref()?
+    //             .refresh_support
+    //     })()
+    //     .unwrap_or_default()
+    // }
 
     // pub fn inlay_hint_resolve_support_properties(&self) -> FxHashSet<&str> {
     //     self.0

--- a/fpp_lsp_server/src/main.rs
+++ b/fpp_lsp_server/src/main.rs
@@ -7,6 +7,7 @@ mod handlers;
 mod lsp_ext;
 mod notification;
 mod request;
+mod uri;
 mod util;
 
 mod lsp;

--- a/fpp_lsp_server/src/uri.rs
+++ b/fpp_lsp_server/src/uri.rs
@@ -1,0 +1,136 @@
+//! Minimal `file://` URI conversions.
+//!
+//! The server only ever needs to translate between absolute local filesystem
+//! paths and `file://` URI strings (which are then parsed into [`lsp_types::Uri`]
+//! or fed to path-based APIs). That is a tiny slice of what the `url` crate
+//! offers, so instead of depending on `url` (and its `idna` /
+//! `form_urlencoded` transitive tree) we implement just those two operations on
+//! top of `percent-encoding`, which is already in the tree via `lsp-types`.
+//!
+//! Behavior mirrors `url::Url::{from_file_path, to_file_path}` for the local,
+//! absolute paths the server deals with: percent-encoding of path bytes,
+//! forward-slash separators, and (on Windows) a `file:///C:/...` drive-letter
+//! layout.
+
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_decode_str, percent_encode};
+use std::path::{Path, PathBuf};
+
+/// Characters left unencoded in a URI path. This is the RFC 3986 `pchar` set
+/// (`unreserved` + `sub-delims` + `:` + `@`) plus `/` as the segment separator.
+/// Everything else — spaces, control characters, non-ASCII bytes — is
+/// percent-encoded.
+const PATH_SET: &AsciiSet = &NON_ALPHANUMERIC
+    // unreserved
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    // sub-delims
+    .remove(b'!')
+    .remove(b'$')
+    .remove(b'&')
+    .remove(b'\'')
+    .remove(b'(')
+    .remove(b')')
+    .remove(b'*')
+    .remove(b'+')
+    .remove(b',')
+    .remove(b';')
+    .remove(b'=')
+    // pchar extras
+    .remove(b':')
+    .remove(b'@')
+    // segment separator
+    .remove(b'/');
+
+/// Serialize an absolute filesystem path into a `file://` URI string.
+///
+/// Returns `Err(())` if the path is not absolute, mirroring
+/// `url::Url::from_file_path`'s contract.
+pub fn from_file_path(path: impl AsRef<Path>) -> Result<String, ()> {
+    let path = path.as_ref();
+    if !path.is_absolute() {
+        return Err(());
+    }
+
+    let mut out = String::from("file://");
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        // Unix paths already begin with `/`, so the empty authority is followed
+        // directly by the encoded path bytes (e.g. `file:///home/a%20b.fpp`).
+        out.extend(percent_encode(path.as_os_str().as_bytes(), PATH_SET));
+    }
+
+    #[cfg(windows)]
+    {
+        // Produce `file:///C:/dir/file`. Windows paths are not raw byte paths,
+        // so require valid Unicode and normalize separators to `/`.
+        let s = path.to_str().ok_or(())?;
+        out.push('/');
+        let normalized = s.replace('\\', "/");
+        out.extend(percent_encode(normalized.as_bytes(), PATH_SET));
+    }
+
+    Ok(out)
+}
+
+/// Parse a `file://` URI string into a filesystem path.
+///
+/// Returns `None` if the string is not a `file://` URI or does not decode to
+/// valid UTF-8. Mirrors the local-path handling of `url::Url::to_file_path`.
+pub fn to_file_path(uri: &str) -> Option<PathBuf> {
+    // `file://` + (empty authority) + path. For local files the authority is
+    // empty, so what follows is the path starting with `/`.
+    let rest = uri.strip_prefix("file://")?;
+    let decoded = percent_decode_str(rest).decode_utf8().ok()?;
+
+    #[cfg(not(windows))]
+    {
+        Some(PathBuf::from(decoded.into_owned()))
+    }
+
+    #[cfg(windows)]
+    {
+        // `/C:/dir/file` -> `C:\dir\file`.
+        let decoded = decoded.into_owned();
+        let trimmed = decoded.strip_prefix('/').unwrap_or(&decoded);
+        Some(PathBuf::from(trimmed.replace('/', "\\")))
+    }
+}
+
+#[cfg(all(test, not(windows)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips_plain_path() {
+        let uri = from_file_path("/proj/custom/locs.fpp").unwrap();
+        assert_eq!(uri, "file:///proj/custom/locs.fpp");
+        assert_eq!(
+            to_file_path(&uri).unwrap(),
+            PathBuf::from("/proj/custom/locs.fpp")
+        );
+    }
+
+    #[test]
+    fn encodes_and_decodes_spaces() {
+        let uri = from_file_path("/proj/a b/c.fpp").unwrap();
+        assert_eq!(uri, "file:///proj/a%20b/c.fpp");
+        assert_eq!(
+            to_file_path(&uri).unwrap(),
+            PathBuf::from("/proj/a b/c.fpp")
+        );
+    }
+
+    #[test]
+    fn relative_path_is_rejected() {
+        assert!(from_file_path("relative/path.fpp").is_err());
+    }
+
+    #[test]
+    fn non_file_uri_is_none() {
+        assert!(to_file_path("http://example.com/x").is_none());
+    }
+}

--- a/fpp_lsp_server/src/util.rs
+++ b/fpp_lsp_server/src/util.rs
@@ -15,6 +15,7 @@ use lsp_types::{
 use serde::de::DeserializeOwned;
 use std::ops::{ControlFlow, Deref};
 use std::str::FromStr;
+use std::sync::Arc;
 
 pub fn from_json<T: DeserializeOwned>(
     what: &'static str,
@@ -911,6 +912,49 @@ pub(crate) fn sm_symbol_at_position<'a>(
     })
 }
 
+/// Resolve a state machine member *definition* at `position` to its state
+/// machine symbol (action, guard, signal, state, or choice).
+///
+/// State machine members (actions, guards, signals, states, choices) are not
+/// entered into the global `symbol_map`; they live only in their state
+/// machine's own analysis. So hovering the name of such a definition would
+/// otherwise fall through to the enclosing `DefStateMachine`, showing the
+/// parent state machine's hover instead of the member's. This resolves the
+/// member definition node the cursor is on to a [`StateMachineSymbol`] built
+/// from that node, mirroring how uses resolve via [`sm_symbol_at_position`].
+///
+/// The returned node is the member definition's own node, used for the hover
+/// range.
+pub(crate) fn sm_def_at_position<'a>(
+    state: &'a GlobalState,
+    document: &Uri,
+    position: BytePos,
+) -> Option<(Node<'a>, &'a StateMachine, StateMachineSymbol)> {
+    let nodes = nodes_at_offset(state, document, position)?;
+
+    // A definition-name hover only applies when the cursor is on the name.
+    if !matches!(nodes.first(), Some(Node::Name(_))) {
+        return None;
+    }
+
+    // Find the enclosing state machine definition and its analysis.
+    let state_machine = enclosing_state_machine(state, &nodes)?;
+
+    // Find the deepest state machine member definition node at the cursor and
+    // build its symbol.
+    nodes.iter().find_map(|n| {
+        let symbol = match n {
+            Node::DefAction(def) => StateMachineSymbol::Action(Arc::new((*def).clone())),
+            Node::DefGuard(def) => StateMachineSymbol::Guard(Arc::new((*def).clone())),
+            Node::DefSignal(def) => StateMachineSymbol::Signal(Arc::new((*def).clone())),
+            Node::DefState(def) => StateMachineSymbol::State(Arc::new((*def).clone())),
+            Node::DefChoice(def) => StateMachineSymbol::Choice(Arc::new((*def).clone())),
+            _ => return None,
+        };
+        Some((*n, state_machine, symbol))
+    })
+}
+
 /// The resolved state machine enclosing the cursor, if any, given the AST nodes
 /// covering the cursor position (innermost first).
 fn enclosing_state_machine<'a>(
@@ -1000,7 +1044,6 @@ pub(crate) fn completion_items_for_sm_state(
     qualifier: &[String],
 ) -> Option<Vec<CompletionItem>> {
     use fpp_ast::{StateMachineMember, StateMember};
-    use std::sync::Arc;
 
     let nodes = nodes_at_offset(state, document, position)?;
     let sm = enclosing_state_machine(state, &nodes)?;

--- a/fpp_lsp_server/src/vfs/mod.rs
+++ b/fpp_lsp_server/src/vfs/mod.rs
@@ -8,7 +8,6 @@ use lsp_types::{
 use rustc_hash::FxHashMap;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
-use url::Url;
 
 use crate::lsp::capabilities::PositionEncoding;
 
@@ -220,11 +219,11 @@ impl Vfs {
                     )
                     .into()),
                     Some(file_path) => {
-                        let uri = Url::from_file_path(file_path).map_err(|_| {
+                        let uri = crate::uri::from_file_path(file_path).map_err(|()| {
                             Error::from(format!("Failed to convert path to URI: {}", file_path))
                         })?;
 
-                        Ok(uri.as_str().to_string())
+                        Ok(uri)
                     }
                 }
             }


### PR DESCRIPTION
This PR allows FPP state machine diagram layouts to be edited which trigger workspace edits to annotations in the FPP state machine. The annotations then hook into the Mermaid codegen backend.

It also implements a "debounce" on analysis so that analysis isn't recomputed on every key-press which can cause some weird lag.

Finally it makes diagnostics push instead of pull which is required with the analysis debouncing mechanism.