### PR TITLE
Permissive Context lookup to avoid unwrap panic with analysis debounce

### DIFF
--- a/fpp_core/src/context.rs
+++ b/fpp_core/src/context.rs
@@ -301,6 +301,15 @@ impl<E: DiagnosticEmitter> CompilerContext<E> {
         self.nodes.get(node.handle)
     }
 
+    /// Fallible variant of [`CompilerContext::node_get`]. Returns `None` when
+    /// the node handle is no longer present in the context (for example, a
+    /// symbol held by a stale analysis snapshot whose translation unit has
+    /// already been garbage collected). Callers that may outlive the nodes they
+    /// reference should prefer this over `node_get`.
+    pub fn node_try_get(&self, node: &Node) -> Option<&NodeData> {
+        self.nodes.try_get(node.handle)
+    }
+
     pub(crate) fn node_get_mut(&mut self, node: &Node) -> &mut NodeData {
         self.nodes.get_mut(node.handle)
     }

--- a/fpp_core/src/map.rs
+++ b/fpp_core/src/map.rs
@@ -70,6 +70,14 @@ impl<V> IdMap<V> {
         self.store.get(&key).unwrap()
     }
 
+    /// Fallible variant of [`IdMap::get`] that returns `None` when the key is
+    /// absent instead of panicking. Used by callers that may hold a stale key
+    /// (e.g. the LSP querying an analysis snapshot whose backing nodes have
+    /// since been garbage collected).
+    pub fn try_get(&self, key: usize) -> Option<&V> {
+        self.store.get(&key)
+    }
+
     pub fn get_mut(&mut self, key: usize) -> &mut V {
         self.store.get_mut(&key).unwrap()
     }

--- a/fpp_lsp_server/src/global_state.rs
+++ b/fpp_lsp_server/src/global_state.rs
@@ -277,6 +277,23 @@ impl GlobalState {
         }
     }
 
+    /// Drain and run every queued task except the debounced `Task::Analysis`,
+    /// leaving `self.analysis` stale (test only). Reproduces the window between
+    /// an edit-driven reprocess and the coalesced analysis in the real loop.
+    pub(crate) fn run_pending_tasks_except_analysis(&mut self) {
+        while let Ok(msg) = self.task_rx.try_recv() {
+            if matches!(msg.task, Task::Analysis) {
+                continue;
+            }
+            self.on_task(msg.task);
+        }
+    }
+
+    /// The current analysis snapshot (test only).
+    pub(crate) fn snapshot_analysis(&self) -> Arc<Analysis> {
+        self.analysis.clone()
+    }
+
     /// The top-level source file registered under `uri`, if any (test only).
     pub(crate) fn source_file_for_uri(&self, uri: &str) -> Option<SourceFile> {
         self.files.get(uri).and_then(|v| v.first().copied())

--- a/fpp_lsp_server/src/handlers.rs
+++ b/fpp_lsp_server/src/handlers.rs
@@ -907,6 +907,24 @@ pub fn handle_completion(
 
     let root = parse.syntax_node();
     let cursor_token = root.token_at_offset(cursor_pos);
+
+    // Don't offer completions when the cursor sits inside a comment. Comments are
+    // trivia the generic branches below happily skip over (via
+    // `non_white_space_left`), so without this guard we'd complete against the
+    // preceding code token as if the comment weren't there. A comment spans
+    // `[start, end)`; treat the cursor as "inside" it anywhere past the leading
+    // `#` (`Single`), and at the trailing edge (`Between` with the comment on the
+    // left). The leading boundary itself (`Between` with the comment on the
+    // right) is still real code position, so completion is allowed there.
+    let in_comment = match &cursor_token {
+        TokenAtOffset::None => false,
+        TokenAtOffset::Single(tok) => tok.kind() == SyntaxKind::COMMENT,
+        TokenAtOffset::Between(l, _) => l.kind() == SyntaxKind::COMMENT,
+    };
+    if in_comment {
+        return Ok(None);
+    }
+
     let expected_error_range = match &cursor_token {
         TokenAtOffset::None => return Ok(None),
         TokenAtOffset::Single(tok) => non_white_space_left(&root, tok.clone())

--- a/fpp_lsp_server/src/util.rs
+++ b/fpp_lsp_server/src/util.rs
@@ -344,11 +344,14 @@ fn formal_param_to_string(state: &GlobalState, param: &FormalParam) -> String {
 pub fn symbol_to_completion_item(state: &GlobalState, symbol: &Symbol) -> CompletionItem {
     let symbol_kind = symbol_kind_name(symbol);
     let description = {
-        let node = state.context.node_get(&symbol.node());
-        if node.pre_annotation.is_empty() {
-            None
-        } else {
-            Some(node.pre_annotation.join(" "))
+        // The symbol may come from a stale analysis snapshot whose backing node
+        // was garbage collected by an intervening `Task::Reprocess` (analysis is
+        // debounced, so a completion request can race ahead of a fresh
+        // snapshot). Degrade to no documentation rather than panicking on a
+        // freed node handle.
+        match state.context.node_try_get(&symbol.node()) {
+            Some(node) if !node.pre_annotation.is_empty() => Some(node.pre_annotation.join(" ")),
+            _ => None,
         }
     };
 

--- a/fpp_lsp_server/src/workspace_tests.rs
+++ b/fpp_lsp_server/src/workspace_tests.rs
@@ -15,6 +15,7 @@
 
 use crate::global_state::{GlobalState, Task};
 use crate::lsp::capabilities::ClientCapabilities;
+use fpp_analysis::semantics::{NameGroup, SymbolInterface};
 use lsp_types::{Uri, WorkspaceFolder};
 use std::path::Path;
 use std::str::FromStr;
@@ -37,7 +38,11 @@ fn index_workspace(folder: &Path) -> GlobalState {
         name: "test".into(),
     }];
 
-    let (tx, _rx) = crossbeam_channel::unbounded();
+    let (tx, rx) = crossbeam_channel::unbounded();
+    // Keep the receiver alive for the lifetime of the process so outgoing
+    // notifications (e.g. progress) sent after this helper returns don't panic
+    // on a closed channel.
+    Box::leak(Box::new(rx));
     let mut state = GlobalState::new(
         Some(workspace_folders),
         tx,
@@ -81,6 +86,134 @@ fn scan_mode_resolves_uses_through_symlinked_root() {
         state.use_def_count(),
         1,
         "the use of `A` in `constant B = A` was not resolved"
+    );
+}
+
+/// A completion request can race ahead of analysis. Analysis is debounced, so
+/// the compiler context can be rebuilt (dropping the nodes of a
+/// no-longer-present translation unit) before the coalesced `Task::Analysis`
+/// refreshes the snapshot. In that window `state.analysis` still holds
+/// `Symbol`s pointing at node handles that are absent from the current context.
+/// Building a completion item for such a stale symbol used to `unwrap()` the
+/// missing node and panic; it must now degrade gracefully instead.
+#[test]
+fn completion_item_survives_stale_symbol_after_context_rebuild() {
+    let dir = fixture_dir("ws_stale_symbol");
+
+    // A pre-annotated constant. The annotation forces `symbol_to_completion_item`
+    // down the branch that reads the symbol's backing node from the context.
+    std::fs::write(
+        dir.join("Top.fpp"),
+        "module M {\n  @ doc\n  constant A = 1\n}\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join(".fpp-lsp"), "scanWorkspace: true\n").unwrap();
+
+    let mut state = index_workspace(&dir);
+
+    // Capture a symbol from the fresh analysis snapshot. Its node currently
+    // resolves against the context.
+    let symbol = state
+        .snapshot_analysis()
+        .global_scope
+        .get(NameGroup::Value, "M")
+        .and_then(|m| state.snapshot_analysis().symbol_scope_map.get(&m).cloned())
+        .and_then(|scope| scope.get_group(NameGroup::Value).get("A"))
+        .expect("constant `A` should be in module `M`'s scope");
+    assert!(
+        state.context.node_try_get(&symbol.node()).is_some(),
+        "captured symbol's node should resolve before the rebuild"
+    );
+
+    // Delete the only source file and reindex. `Task::LoadFullWorkspace` builds a
+    // fresh `CompilerContext` from the (now empty) file set, so the node handle
+    // the captured symbol points at no longer exists. Run every task *except* the
+    // debounced analysis so `state.analysis` remains the stale pre-rebuild
+    // snapshot — exactly the racing-completion window.
+    std::fs::remove_file(dir.join("Top.fpp")).unwrap();
+    state.on_task(Task::LoadFullWorkspace);
+    state.run_pending_tasks_except_analysis();
+    assert!(
+        state.context.node_try_get(&symbol.node()).is_none(),
+        "captured symbol's node should have been dropped by the context rebuild"
+    );
+
+    // Building a completion item for the stale symbol must not panic.
+    let item = crate::util::symbol_to_completion_item(&state, &symbol);
+    assert_eq!(item.label, symbol.name().data);
+}
+
+/// Build a `CompletionParams` for `uri` at a zero-based `line`/`character`.
+fn completion_params_at(uri: &str, line: u32, character: u32) -> lsp_types::CompletionParams {
+    lsp_types::CompletionParams {
+        text_document_position: lsp_types::TextDocumentPositionParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: Uri::from_str(uri).unwrap(),
+            },
+            position: lsp_types::Position { line, character },
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+        context: None,
+    }
+}
+
+/// Flatten a completion response into its item list (empty when `None`).
+fn completion_items(resp: Option<lsp_types::CompletionResponse>) -> Vec<lsp_types::CompletionItem> {
+    match resp {
+        None => vec![],
+        Some(lsp_types::CompletionResponse::Array(items)) => items,
+        Some(lsp_types::CompletionResponse::List(list)) => list.items,
+    }
+}
+
+/// Completion must not fire while the cursor is inside a `#` comment. Comments
+/// are trivia the completion resolver skips over, so without an explicit guard
+/// a cursor parked in a trailing comment resolves against the preceding code
+/// token (here the dangling `M.`) and wrongly offers that scope's members.
+#[test]
+fn completion_suppressed_inside_comment() {
+    let dir = fixture_dir("ws_comment_completion");
+
+    // `type T = M.` leaves a dangling member access; the trailing `# comment`
+    // is where the cursor sits. Line/column are zero-based: the `#` is at
+    // column 14 of line 1, so column 16 is inside the comment text.
+    let text = "module M {\n  type T = M. # comment\n}\n";
+    std::fs::write(dir.join("Top.fpp"), text).unwrap();
+    std::fs::write(dir.join(".fpp-lsp"), "scanWorkspace: true\n").unwrap();
+
+    let mut state = index_workspace(&dir);
+
+    let top_uri = crate::uri::from_file_path(dir.join("Top.fpp")).unwrap();
+    // Open the document in the VFS so the completion handler can read it.
+    state.vfs.did_open(lsp_types::DidOpenTextDocumentParams {
+        text_document: lsp_types::TextDocumentItem {
+            uri: Uri::from_str(&top_uri).unwrap(),
+            language_id: "fpp".into(),
+            version: 1,
+            text: text.to_string(),
+        },
+    });
+
+    // Sanity check: completion at the dangling dot (before the comment) *does*
+    // resolve `M`'s members, so this fixture exercises the resolving path.
+    let at_dot = completion_items(
+        crate::handlers::handle_completion(&state, completion_params_at(&top_uri, 1, 13))
+            .expect("completion at dot should not error"),
+    );
+    assert!(
+        at_dot.iter().any(|i| i.label == "T"),
+        "fixture precondition: dangling `M.` should offer member `T`, got {at_dot:?}"
+    );
+
+    // Cursor inside the trailing comment must yield no completions.
+    let in_comment = completion_items(
+        crate::handlers::handle_completion(&state, completion_params_at(&top_uri, 1, 16))
+            .expect("completion inside comment should not error"),
+    );
+    assert!(
+        in_comment.is_empty(),
+        "expected no completions inside a comment, got {in_comment:?}"
     );
 }
 


### PR DESCRIPTION
Because we are debouncing the analysis in the LSP, sometimes the node_ids from the AST become stale. We cannot unwrap context info from the analysis during other LSP replies. It does 'best effort' lookup from the FPP core context given a stale analysis node_id