### PR TITLE
Update formatter after review

### DIFF
--- a/fpp_format/README.md
+++ b/fpp_format/README.md
@@ -18,7 +18,7 @@ fpp-format --check path/to/model.fpp
 cat path/to/model.fpp | fpp-format --stdin
 
 # Override the indentation width and maximum line length
-fpp-format --indent 4 --line-length 100 path/to/model.fpp
+fpp-format --indent 2 --line-length 100 path/to/model.fpp
 ```
 
 ## Options
@@ -28,7 +28,7 @@ fpp-format --indent 4 --line-length 100 path/to/model.fpp
 | `--check`              | Check formatting without writing; exit `1` if a file is unformatted. |
 | `--stdin`              | Read from stdin and write to stdout (default when no files given). |
 | `--recursive-includes` | Also follow `include` specifiers and format reachable `.fppi` fragments. |
-| `--indent <N>`         | Number of spaces per indentation level. Overrides `.fpp-format` (default: `2`). |
+| `--indent <N>`         | Number of spaces per indentation level. Overrides `.fpp-format` (default: `4`). |
 | `--line-length <N>`    | Maximum line width before specs explode their clauses. Overrides `.fpp-format` (default: `80`). |
 | `--entry <RULE>`       | Select the parser entrypoint / grammar rule (see below).          |
 | `--help`               | Print usage.                                                       |
@@ -47,7 +47,7 @@ ignored:
 
 ```ini
 # .fpp-format
-indent = 2
+indent = 4
 line-length = 80
 ```
 
@@ -55,7 +55,7 @@ Supported keys:
 
 | Key           | Description                              | Default |
 | ------------- | ---------------------------------------- | ------- |
-| `indent`      | Spaces per indentation level.            | `2`     |
+| `indent`      | Spaces per indentation level.            | `4`     |
 | `line-length` | Maximum line width before clauses break. | `80`    |
 
 Precedence, lowest to highest: built-in defaults → `.fpp-format` file →

--- a/fpp_format/src/config.rs
+++ b/fpp_format/src/config.rs
@@ -12,7 +12,7 @@
 //!
 //! ```text
 //! # Spaces per indentation level
-//! indent = 2
+//! indent = 4
 //! # Maximum line width before specs explode their clauses
 //! line-length = 80
 //! ```

--- a/fpp_format/src/formatter.rs
+++ b/fpp_format/src/formatter.rs
@@ -32,16 +32,19 @@ impl Formatter {
     // ---- containers (ROOT / member lists) ------------------------------
 
     fn lower_container(&self, node: &SyntaxNode) -> Doc {
-        join_items(&self.collect_items(node))
+        join_items(&self.collect_items(node).items)
     }
 
     /// Collect member items from a container, attaching trailing comments /
     /// post-annotations to the preceding item and tracking blank lines.
-    fn collect_items(&self, node: &SyntaxNode) -> Vec<Item> {
+    fn collect_items(&self, node: &SyntaxNode) -> Collected {
         let mut items: Vec<Item> = Vec::new();
         let mut saw_eol = false;
         let mut blank = false;
         let mut started = false;
+        // Whether a blank line separates the last member from the closing
+        // delimiter (used to preserve a trailing blank inside a module body).
+        let mut trailing_blank = false;
         // Newlines seen in the current run of trivia since the last real item.
         // The lexer splits a blank line that carries trailing whitespace into
         // separate EOL tokens (`"\n"` WHITESPACE `"\n"`), so a blank line must
@@ -62,12 +65,16 @@ impl Formatter {
                         saw_eol = true;
                     }
                     LEFT_CURLY | LEFT_PAREN | LEFT_SQUARE => started = true,
-                    RIGHT_CURLY | RIGHT_PAREN | RIGHT_SQUARE => {}
+                    RIGHT_CURLY | RIGHT_PAREN | RIGHT_SQUARE => {
+                        if started && newlines >= 2 {
+                            trailing_blank = true;
+                        }
+                    }
                     COMMENT => {
                         if saw_eol || items.is_empty() {
                             items.push(Item::line_swallowing(Doc::text(t.text()), blank));
                         } else {
-                            attach(&mut items, Doc::text(t.text()));
+                            attach(&mut items, Doc::text(t.text()), " ");
                         }
                         saw_eol = false;
                         blank = false;
@@ -85,9 +92,12 @@ impl Formatter {
                         if items.is_empty() {
                             items.push(Item::line_swallowing(Doc::text(t.text()), blank));
                         } else {
+                            // A `@<` post-annotation is separated from the item it
+                            // documents by two spaces (before alignment padding).
                             attach(
                                 &mut items,
                                 Doc::anchor(AnchorKind::PostAnnotation, Doc::text(t.text())),
+                                "  ",
                             );
                         }
                         saw_eol = false;
@@ -111,7 +121,10 @@ impl Formatter {
                 started = true;
             }
         }
-        items
+        Collected {
+            items,
+            trailing_blank,
+        }
     }
 
     // ---- dispatch ------------------------------------------------------
@@ -170,27 +183,39 @@ impl Formatter {
 
     fn lower_member_list(&self, node: &SyntaxNode) -> Doc {
         let cfg = list_cfg(node.kind());
-        let items = self.collect_items(node);
+        let Collected {
+            items,
+            trailing_blank,
+        } = self.collect_items(node);
         let always = match cfg.mode {
             ListMode::Always => true,
             ListMode::Auto => false,
         };
         let force_block = always || items.iter().any(|i| i.comment);
 
+        // A definition-scope body preserves a single blank line at its start
+        // and end when the source had one; other block bodies (structs, enums,
+        // sub-blocks, inline lists) always hug their braces.
+        let keep_blank = preserves_edge_blanks(node.kind());
+
         if items.is_empty() {
             return match cfg.mode {
+                // An empty scope keeps its lone blank line if the source had
+                // one (it is simultaneously the body's start and end).
                 ListMode::Always => Doc::concat(vec![
                     Doc::text(cfg.open),
-                    Doc::hardline(),
+                    break_lines(keep_blank && trailing_blank),
                     Doc::text(cfg.close),
                 ]),
                 ListMode::Auto => Doc::text(format!("{}{}", cfg.open, cfg.close)),
             };
         }
+        let lead_blank = keep_blank && items.first().is_some_and(|i| i.blank_before);
+        let trail_blank = keep_blank && trailing_blank;
 
         let pad = if cfg.open == "{" { " " } else { "" };
         let (open_line, body) = if force_block {
-            (Doc::hardline(), join_items(&items))
+            (break_lines(lead_blank), join_items(&items))
         } else {
             (
                 Doc::Line {
@@ -214,7 +239,7 @@ impl Formatter {
         match cfg.close_style {
             Close::Dedent => {
                 inner.push(if force_block {
-                    Doc::hardline()
+                    break_lines(trail_blank)
                 } else {
                     Doc::Line {
                         flat: pad,
@@ -225,7 +250,7 @@ impl Formatter {
             }
             Close::Trail => {
                 inner.push(if force_block {
-                    Doc::hardline()
+                    break_lines(trail_blank)
                 } else {
                     Doc::Line {
                         flat: "",
@@ -369,6 +394,21 @@ impl Formatter {
 // Items
 // ============================================================================
 
+/// The members of a container plus whether a blank line preceded its close.
+struct Collected {
+    items: Vec<Item>,
+    trailing_blank: bool,
+}
+
+/// A hard break, doubled to `\n\n` (an intentional blank line) when `blank`.
+fn break_lines(blank: bool) -> Doc {
+    if blank {
+        Doc::concat(vec![Doc::hardline(), Doc::hardline()])
+    } else {
+        Doc::hardline()
+    }
+}
+
 struct Item {
     doc: Doc,
     blank_before: bool,
@@ -396,12 +436,15 @@ impl Item {
     }
 }
 
-fn attach(items: &mut [Item], extra: Doc) {
+/// Append `extra` to the preceding item on the same line, separated by `gap`
+/// (a trailing comment uses one space, a `@<` annotation two). If that item is
+/// itself line-swallowing, `extra` drops to the next line instead.
+fn attach(items: &mut [Item], extra: Doc, gap: &str) {
     if let Some(last) = items.last_mut() {
         let sep = if last.comment {
             Doc::hardline()
         } else {
-            Doc::text(" ")
+            Doc::text(gap)
         };
         let d = std::mem::replace(&mut last.doc, Doc::Nil);
         last.doc = Doc::concat(vec![d, sep, extra]);
@@ -440,6 +483,23 @@ fn join_items_sep(items: &[Item], sep: Doc) -> Doc {
 
 fn is_explodable(kind: SyntaxKind) -> bool {
     kind.is_spec() || kind == DEF_COMPONENT_INSTANCE
+}
+
+/// Whether a block body preserves a single blank line at its start and end when
+/// the source had one. True for definition scopes and connection blocks; other
+/// bodies (structs, enums, packet sub-blocks, inline lists) hug their
+/// delimiters.
+fn preserves_edge_blanks(kind: SyntaxKind) -> bool {
+    match kind {
+        MODULE_MEMBER_LIST
+        | COMPONENT_MEMBER_LIST
+        | INTERFACE_MEMBER_LIST
+        | TOPOLOGY_MEMBER_LIST
+        | STATE_MACHINE_MEMBER_LIST
+        | STATE_MEMBER_LIST
+        | CONNECTION_MEMBER_LIST => true,
+        _ => false,
+    }
 }
 
 fn is_clause_node(kind: SyntaxKind) -> bool {
@@ -561,8 +621,18 @@ fn sep_doc(prev: &SyntaxToken, cur: &SyntaxToken) -> Doc {
 
 /// Flat inter-token separator (" " or "").
 fn flat_sep(prev: &SyntaxToken, cur: &SyntaxToken) -> &'static str {
+    // A `@<` post-annotation is always preceded by two spaces, matching the
+    // member-list path in `attach`.
+    if cur.kind() == POST_ANNOTATION {
+        return "  ";
+    }
     if prev.kind() == DOT || cur.kind() == DOT {
         return "";
+    }
+    // The enum representation-type colon (`enum E : U8`) takes a leading space,
+    // unlike the tight `name: Type` colon of struct fields and formal params.
+    if cur.kind() == COLON && cur.parent().is_some_and(|p| p.kind() == DEF_ENUM) {
+        return " ";
     }
     let cur_tight = match cur.kind() {
         COLON | COMMA | SEMI | RIGHT_PAREN | RIGHT_SQUARE => true,

--- a/fpp_format/src/lib.rs
+++ b/fpp_format/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::include::{FormattedUnit, format_file_recursive};
 /// Configuration options for the formatter
 #[derive(Debug, Clone)]
 pub struct FormatOptions {
-    /// Number of spaces per indentation level (default: 2)
+    /// Number of spaces per indentation level (default: 4)
     pub indent_width: usize,
     /// Maximum line width; specs wider than this explode their clauses and
     /// group-style member lists break onto multiple lines (default: 80)
@@ -27,7 +27,7 @@ pub struct FormatOptions {
 }
 
 /// Default number of spaces per indentation level.
-pub const DEFAULT_INDENT_WIDTH: usize = 2;
+pub const DEFAULT_INDENT_WIDTH: usize = 4;
 /// Default maximum line width.
 pub const DEFAULT_MAX_LINE_WIDTH: usize = 80;
 
@@ -129,9 +129,9 @@ mod tests {
 
     #[test]
     fn test_default_options() {
-        // The default formatting profile is 2-space indent, 80-column width.
+        // The default formatting profile is 4-space indent, 80-column width.
         let options = FormatOptions::default();
-        assert_eq!(options.indent_width, 2);
+        assert_eq!(options.indent_width, 4);
         assert_eq!(options.max_line_width, 80);
         assert_eq!(options.indent_width, DEFAULT_INDENT_WIDTH);
         assert_eq!(options.max_line_width, DEFAULT_MAX_LINE_WIDTH);
@@ -382,12 +382,12 @@ module Outer {
         let formatted =
             format_text(input, TopEntryPoint::Module, FormatOptions::default()).unwrap();
         assert_eq!(
-            formatted, "module M {\n  constant a = 1\n\n  constant b = 2\n}\n",
+            formatted, "module M {\n    constant a = 1\n\n    constant b = 2\n}\n",
             "trailing-whitespace blank line not preserved:\n{}",
             formatted
         );
         // Same content without the stray spaces must format identically.
-        let clean = "module M {\n  constant a = 1\n\n  constant b = 2\n}\n";
+        let clean = "module M {\n    constant a = 1\n\n    constant b = 2\n}\n";
         let clean_formatted =
             format_text(clean, TopEntryPoint::Module, FormatOptions::default()).unwrap();
         assert_eq!(formatted, clean_formatted);
@@ -402,7 +402,7 @@ module Outer {
         let formatted =
             format_text(input, TopEntryPoint::Module, FormatOptions::default()).unwrap();
         assert_eq!(
-            formatted, "module M {\n  constant a = 1\n\n  constant b = 2\n}\n",
+            formatted, "module M {\n    constant a = 1\n\n    constant b = 2\n}\n",
             "blank run not collapsed to one:\n{}",
             formatted
         );

--- a/fpp_format/src/main.rs
+++ b/fpp_format/src/main.rs
@@ -14,7 +14,7 @@ use std::process;
 ///
 /// The indentation width and maximum line length are read from the nearest
 /// `.fpp-format` file (searched upward from each file's directory), falling
-/// back to built-in defaults (2-space indent, 80-column width). The --indent
+/// back to built-in defaults (4-space indent, 80-column width). The --indent
 /// and --line-length flags override whatever the file specifies.
 #[derive(Parser, Debug)]
 #[command(version, author, about, long_about)]

--- a/fpp_format/tests/annotations.ref.fpp
+++ b/fpp_format/tests/annotations.ref.fpp
@@ -1,46 +1,46 @@
 # Standalone comment at module level
 @ Pre-annotation for module
 module AnnotatedModule {
-  # Comment inside module
+    # Comment inside module
 
-  @ Pre-annotation for constant
-  constant MAX_VALUE = 100 @< Post-annotation for constant
+    @ Pre-annotation for constant
+    constant MAX_VALUE = 100  @< Post-annotation for constant
 
-  # Standalone comment before enum
-  @ Enum with annotations
-  enum Status {
-    @ Active status
-    ACTIVE = 0 @< Post-annotation for ACTIVE
-    # Comment between enum members
-    @ Idle status
-    IDLE = 1 @< Post-annotation for IDLE
-    STOPPED # inline comment
-  } default IDLE @< Post-annotation for enum
+    # Standalone comment before enum
+    @ Enum with annotations
+    enum Status {
+        @ Active status
+        ACTIVE = 0  @< Post-annotation for ACTIVE
+        # Comment between enum members
+        @ Idle status
+        IDLE = 1  @< Post-annotation for IDLE
+        STOPPED # inline comment
+    } default IDLE  @< Post-annotation for enum
 
-  # Comment before type
-  @ Type alias annotation
-  type MyType = U32 @< Post-annotation for type
+    # Comment before type
+    @ Type alias annotation
+    type MyType = U32  @< Post-annotation for type
 
-  @ Array with annotations
-  array DataArray = [50] F32 default 0.0 @< Post-annotation for array
+    @ Array with annotations
+    array DataArray = [50] F32 default 0.0  @< Post-annotation for array
 
-  # Multiple standalone comments
+    # Multiple standalone comments
 
-  # Can appear in sequence
+    # Can appear in sequence
 
-  @ Struct with member annotations
-  struct Record {
-    @ Field x annotation
-    x: U32 @< Post-annotation for x
-    # Comment between fields
-    y: F32 # inline comment on field
-    @ Field z annotation
-    z: string @< Post-annotation for z
-  } @< Post-annotation for struct
+    @ Struct with member annotations
+    struct Record {
+        @ Field x annotation
+        x: U32  @< Post-annotation for x
+        # Comment between fields
+        y: F32 # inline comment on field
+        @ Field z annotation
+        z: string  @< Post-annotation for z
+    }  @< Post-annotation for struct
 
-  @ Constant with inline and post
-  constant MIN_VALUE = 0 # inline comment
-  @< Post-annotation for constant
+    @ Constant with inline and post
+    constant MIN_VALUE = 0 # inline comment
+    @< Post-annotation for constant
 
-  # Final standalone comment
-} @< Post-annotation for module
+    # Final standalone comment
+}  @< Post-annotation for module

--- a/fpp_format/tests/array-struct.ref.fpp
+++ b/fpp_format/tests/array-struct.ref.fpp
@@ -1,53 +1,53 @@
 @ Arrays and structs with various formatting
 module DataTypes {
-  @ Simple array
-  array SimpleArray = [10] U32
+    @ Simple array
+    array SimpleArray = [10] U32
 
-  @ Array with default
-  array DefaultArray = [5] F32 default 0.0
+    @ Array with default
+    array DefaultArray = [5] F32 default 0.0
 
-  @ Array with format
-  array FormattedArray = [20] U32 default 100 format "{} units"
+    @ Array with format
+    array FormattedArray = [20] U32 default 100 format "{} units"
 
-  @ String array
-  array StringArray = [3] string
+    @ String array
+    array StringArray = [3] string
 
-  @ Multi-dimensional via nested arrays
-  array MatrixRow = [10] F32
-  array Matrix = [5] MatrixRow
+    @ Multi-dimensional via nested arrays
+    array MatrixRow = [10] F32
+    array Matrix = [5] MatrixRow
 
-  @ Simple struct
-  struct Point {
-    x: U32
-    y: U32
-  }
+    @ Simple struct
+    struct Point {
+        x: U32
+        y: U32
+    }
 
-  @ Struct with format on fields
-  struct Measurement {
-    value: F32 format "{} meters"
-    timestamp: U32
-    unitCode: U8
-  }
+    @ Struct with format on fields
+    struct Measurement {
+        value: F32 format "{} meters"
+        timestamp: U32
+        unitCode: U8
+    }
 
-  @ Struct with array field
-  struct Data {
-    samples: [100] F32
-    count: U32
-  }
+    @ Struct with array field
+    struct Data {
+        samples: [100] F32
+        count: U32
+    }
 
-  @ Struct with default block
-  struct Config {
-    enabled: bool
-    timeout: U32
-    maxRetries: U8
-  } default { enabled = true, timeout = 1000, maxRetries = 3 }
+    @ Struct with default block
+    struct Config {
+        enabled: bool
+        timeout: U32
+        maxRetries: U8
+    } default { enabled = true, timeout = 1000, maxRetries = 3 }
 
-  @ Nested struct
-  struct SystemState {
-    position: Point
-    measurement: Measurement
-  } default {
-    position = { x = 0, y = 0 }
-    measurement = { value = 0.0, timestamp = 0, unitCode = 1 }
-  }
+    @ Nested struct
+    struct SystemState {
+        position: Point
+        measurement: Measurement
+    } default {
+        position = { x = 0, y = 0 }
+        measurement = { value = 0.0, timestamp = 0, unitCode = 1 }
+    }
 }

--- a/fpp_format/tests/binary-expressions.ref.fpp
+++ b/fpp_format/tests/binary-expressions.ref.fpp
@@ -1,5 +1,5 @@
 module F {
-  constant a = 2 + 3 * 4 / 4
-  constant b = 2 + 3
-  constant c = 1 - 2
+    constant a = 2 + 3 * 4 / 4
+    constant b = 2 + 3
+    constant c = 1 - 2
 }

--- a/fpp_format/tests/blank-lines.fpp
+++ b/fpp_format/tests/blank-lines.fpp
@@ -1,0 +1,85 @@
+# Definition-scope bodies (module, component, interface, topology, state
+# machine), individual states, and connection blocks preserve a single blank
+# line at their start and end when the source has one. Data-type bodies
+# (struct, enum) always hug their delimiters.
+
+module WithBoth {
+
+  constant a = 1
+
+}
+
+module LeadingOnly {
+
+  constant b = 2
+}
+
+module TrailingOnly {
+  constant c = 3
+
+}
+
+module Nested {
+
+  module Inner {
+
+
+    constant d = 4
+
+
+  }
+
+  struct S {
+
+    x: U32
+
+  }
+
+}
+
+module EmptyWithBlank {
+
+}
+
+module EmptyNoBlank {
+}
+
+active component Comp {
+
+  sync input port pIn: P
+
+  struct Inner {
+
+    x: U32
+
+  }
+
+}
+
+interface Iface {
+
+  sync input port pIn: P
+
+}
+
+topology Topo {
+
+  connections C {
+
+    a.out -> b.in
+
+  }
+
+}
+
+state machine SM {
+
+  initial enter S
+
+  state S {
+
+    on x enter S
+
+  }
+
+}

--- a/fpp_format/tests/blank-lines.ref.fpp
+++ b/fpp_format/tests/blank-lines.ref.fpp
@@ -1,0 +1,79 @@
+# Definition-scope bodies (module, component, interface, topology, state
+# machine), individual states, and connection blocks preserve a single blank
+# line at their start and end when the source has one. Data-type bodies
+# (struct, enum) always hug their delimiters.
+
+module WithBoth {
+
+    constant a = 1
+
+}
+
+module LeadingOnly {
+
+    constant b = 2
+}
+
+module TrailingOnly {
+    constant c = 3
+
+}
+
+module Nested {
+
+    module Inner {
+
+        constant d = 4
+
+    }
+
+    struct S {
+        x: U32
+    }
+
+}
+
+module EmptyWithBlank {
+
+}
+
+module EmptyNoBlank {
+}
+
+active component Comp {
+
+    sync input port pIn: P
+
+    struct Inner {
+        x: U32
+    }
+
+}
+
+interface Iface {
+
+    sync input port pIn: P
+
+}
+
+topology Topo {
+
+    connections C {
+
+        a.out -> b.in
+
+    }
+
+}
+
+state machine SM {
+
+    initial enter S
+
+    state S {
+
+        on x enter S
+
+    }
+
+}

--- a/fpp_format/tests/comments.ref.fpp
+++ b/fpp_format/tests/comments.ref.fpp
@@ -1,6 +1,6 @@
 # Top level comment
 module F {
-  # Comment before constant
-  constant a = 1 # inline comment
-  constant b = 2
+    # Comment before constant
+    constant a = 1 # inline comment
+    constant b = 2
 }

--- a/fpp_format/tests/component-extra.ref.fpp
+++ b/fpp_format/tests/component-extra.ref.fpp
@@ -1,66 +1,70 @@
 @ Component member variants missing from the main component fixture
 queued component ExtraComp {
-  @ Command with queue-full behaviors
-  async command Enqueue opcode 0x2 priority 3 drop
-  async command Hooked opcode 0x3 hook
-  sync command Blocking opcode 0x4 block
+    @ Command with queue-full behaviors
+    async command Enqueue opcode 0x2 priority 3 drop
+    async command Hooked opcode 0x3 hook
+    sync command Blocking opcode 0x4 block
 
-  @ Command with interleaved annotations on arguments
-  @ If $block == Svc.BlockState.BLOCK this command will wait for completion.
-  async command RUN(
-    fileName: string size FileNameStringSize @< The name of the sequence file
-    $block: Svc.BlockState                   @< Return command status when complete or not
-  ) \
-    opcode 0x0
+    @ Command with interleaved annotations on arguments
+    @ If $block == Svc.BlockState.BLOCK this command will wait for completion.
+    async command RUN(
+        fileName: string size FileNameStringSize  @< The name of the sequence file
+        $block: Svc.BlockState                    @< Return command status when complete or not
+    ) \
+        opcode 0x0
 
-  @ Wait for the interpreter to finish and return it's result as a CmdResponse
-  async command WAIT opcode 0x1
+    @ Wait for the interpreter to finish and return it's result as a CmdResponse
+    async command WAIT opcode 0x1
 
-  # async command RUN_ARGS(
-  #                       fileName: string size FileNameStringSize @< The name of the sequence file
-  #                       $block: Svc.BlockState @< Return command status when complete or not
-  #                       buffer: Svc.SeqArgs @< Arguments to pass to the sequencer
-  #                     ) \
-  #     opcode 1 priority 7 assert
+    # async command RUN_ARGS(
+    #                       fileName: string size FileNameStringSize @< The name of the sequence file
+    #                       $block: Svc.BlockState @< Return command status when complete or not
+    #                       buffer: Svc.SeqArgs @< Arguments to pass to the sequencer
+    #                     ) \
+    #     opcode 1 priority 7 assert
 
-  @ Guarded input port
-  guarded input port guardedIn: DataPort
+    @ Guarded input port
+    guarded input port guardedIn: DataPort
 
-  @ Serial port instances
-  async input port serialIn: serial
-  output port serialOut: serial
+    @ Serial port instances
+    async input port serialIn: serial
+    output port serialOut: serial
 
-  @ Telemetry with update on change
-  telemetry changing: U32 id 0x10 update on change
+    @ Telemetry with update on change
+    telemetry changing: U32 id 0x10 update on change
 
-  @ Telemetry with only high limits
-  telemetry hot: F32 \
-    id 0x11 \
-    high {
-      red 100.0
-    }
+    @ Telemetry with only high limits
+    telemetry hot: F32 \
+        id 0x11 \
+        high {
+            red 100.0
+        }
 
-  @ Event with warning-low severity
-  event Warned() severity warning low id 0x20 format "warned"
+    @ Event with warning-low severity
+    event Warned() severity warning low id 0x20 format "warned"
 
-  @ Event with diagnostic severity and throttle every
-  event Diag(code: U32) severity diagnostic id 0x21 format "diag {}" throttle 5
+    @ Event with diagnostic severity and throttle every
+    event Diag(code: U32) \
+        severity diagnostic \
+        id 0x21 \
+        format "diag {}" \
+        throttle 5
 
-  @ Event with command severity
-  event Cmd() severity command id 0x22 format "cmd"
+    @ Event with command severity
+    event Cmd() severity command id 0x22 format "cmd"
 
-  @ Text-event special port
-  text event port textEventOut
+    @ Text-event special port
+    text event port textEventOut
 
-  @ Special ports: command recv/reg/resp, product variants
-  command recv port cmdIn
-  command reg port cmdRegIn
-  command resp port cmdResp
-  product get port prodGet
-  product recv port prodRecv
-  product request port prodReq
-  product send port prodSend
+    @ Special ports: command recv/reg/resp, product variants
+    command recv port cmdIn
+    command reg port cmdRegIn
+    command resp port cmdResp
+    product get port prodGet
+    product recv port prodRecv
+    product request port prodReq
+    product send port prodSend
 
-  @ Param with save opcode
-  param saved: U32 default 0 id 0x30 save opcode 0x31
+    @ Param with save opcode
+    param saved: U32 default 0 id 0x30 save opcode 0x31
 }

--- a/fpp_format/tests/component-inner.ref.fpp
+++ b/fpp_format/tests/component-inner.ref.fpp
@@ -6,10 +6,10 @@
 @
 @ If $block == Svc.BlockState.BLOCK this command will wait for complemention.
 async command RUN(
-  fileName: string size FileNameStringSize @< The name of the sequence file
-  $block: Svc.BlockState                   @< Return command status when complete or not
+    fileName: string size FileNameStringSize  @< The name of the sequence file
+    $block: Svc.BlockState                    @< Return command status when complete or not
 ) \
-  opcode 0x0
+    opcode 0x0
 
 @ Wait for the interpreter to finish and return it's result as a CmdResponse
 async command WAIT opcode 0x1
@@ -18,24 +18,24 @@ async command WAIT opcode 0x1
 @ This command loads the module with a empty name meaning only a single module may be loaded.
 @ To allow multiple modules, use the `LOAD_NAME` command instead.
 async command LOAD(
-  fileName: string size FileNameStringSize @< The name of the sequence file
+    fileName: string size FileNameStringSize  @< The name of the sequence file
 ) \
-  opcode 0x2
+    opcode 0x2
 
 @ Load and validate a WebAssembly module into the store. This module is given a name so that
 @ it's exports can be referenced by other modules.
 async command LOAD_NAME(
-  fileName: string size FileNameStringSize @< The name of the sequence file
-  name: string size 16                     @< WebAssembly module name, must not conflict with previously loaded modules
+    fileName: string size FileNameStringSize  @< The name of the sequence file
+    name: string size 16                      @< WebAssembly module name, must not conflict with previously loaded modules
 ) \
-  opcode 0x3
+    opcode 0x3
 
 @ Invoke a main function from a loaded module
 async command INVOKE(
-  $module: string size 16 @< Name of the module to invoke a function from
-  $block: Svc.BlockState
+    $module: string size 16  @< Name of the module to invoke a function from
+    $block: Svc.BlockState
 ) \
-  opcode 0x4
+    opcode 0x4
 
 @ Cancels a running or validated sequence. After running CANCEL, the sequencer should return to IDLE
 @ This completely clears the store.

--- a/fpp_format/tests/component.ref.fpp
+++ b/fpp_format/tests/component.ref.fpp
@@ -1,115 +1,119 @@
 @ Component for testing
 active component TestComponent {
-  @ Command 1
-  async command StartTest(testId: U32, timeout: F32) \
-    opcode 0x10 \
-    priority 5 \
-    assert
+    @ Command 1
+    async command StartTest(testId: U32, timeout: F32) \
+        opcode 0x10 \
+        priority 5 \
+        assert
 
-  @ Command 2
-  sync command StopTest
+    @ Command 2
+    sync command StopTest
 
-  @ Telemetry channels
-  telemetry temperature: F32 \
-    id 0x01 \
-    update always \
-    format "{} C" \
-    low {
-      yellow 10.0
-      orange 5.0
-      red 0.0
-    } \
-    high {
-      yellow 50.0
-      orange 60.0
-      red 70.0
+    @ Telemetry channels
+    telemetry temperature: F32 \
+        id 0x01 \
+        update always \
+        format "{} C" \
+        low {
+            yellow 10.0
+            orange 5.0
+            red 0.0
+        } \
+        high {
+            yellow 50.0
+            orange 60.0
+            red 70.0
+        }
+
+    telemetry statusCode: U32 id 0x02
+
+    @ Events
+    event TestStarted(testId: U32) \
+        severity activity high \
+        id 0x100 \
+        format "Test {} started" \
+        throttle 10
+
+    event TestFailed() severity fatal format "Test failed"
+
+    @ A COMMAND event emitted by the guest program
+    event LogCommand(msg: string size 128) severity command format "{}"
+
+    @ A COMMAND event emitted by the guest program
+    event LogCommand(msg: string size 128) severity command format "{}"
+
+    event ManyArguments(
+        r0: U8
+        r1: U8
+        r2: U8
+        r3: U8
+        r4: U8
+        r5: U8
+        r6: U8
+        r7: U8
+        r8: U8
+        r9: U8
+        rA: U8
+        rB: U8
+        rC: U8
+        rD: U8
+        rE: U8
+        rF: U8
+    ) \
+        severity activity low \
+        format "{x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x}"
+
+    @ Parameters
+    param maxIterations: U32 \
+        default 100 \
+        id 0x20 \
+        set opcode 0x21 \
+        save opcode 0x22
+
+    external param configFile: string id 0x30
+
+    @ Port instances
+    async input port dataIn: [10] DataPort priority 10 drop
+    output port dataOut: [5] DataPort
+
+    sync input port controlIn: ControlPort priority 5 assert
+
+    command recv port cmdRecv
+    command reg port cmdReg
+    telemetry port tlmOut
+    event port eventOut
+    time get port timeGet
+    param get port prmGet
+    param set port prmSet
+
+    @ Internal ports
+    internal port ProcessData(data: U32, sz: U32) priority 10 block
+
+    @ Port matching
+    match dataIn with dataOut
+
+    @ Container and record
+    product container TestContainer id 0x50 default priority 5
+    product record TestRecord: U32 array id 0x60
+
+    @ State machine
+    state machine TestSM
+    state machine instance smInst: TestSM priority 10 hook
+
+    @ Type definitions inside component
+    type LocalType = U32
+    array LocalArray = [3] F32 default 0.0
+    struct LocalStruct {
+        x: U32
+        y: F32
+        z: string
     }
+    enum LocalEnum {
+        IDLE
+        RUNNING
+        STOPPED
+    } default IDLE
 
-  telemetry statusCode: U32 id 0x02
-
-  @ Events
-  event TestStarted(testId: U32) \
-    severity activity high \
-    id 0x100 \
-    format "Test {} started" \
-    throttle 10
-
-  event TestFailed() severity fatal format "Test failed"
-
-  @ A COMMAND event emitted by the guest program
-  event LogCommand(msg: string size 128) severity command format "{}"
-
-  @ A COMMAND event emitted by the guest program
-  event LogCommand(msg: string size 128) severity command format "{}"
-
-  event ManyArguments(
-    r0: U8
-    r1: U8
-    r2: U8
-    r3: U8
-    r4: U8
-    r5: U8
-    r6: U8
-    r7: U8
-    r8: U8
-    r9: U8
-    rA: U8
-    rB: U8
-    rC: U8
-    rD: U8
-    rE: U8
-    rF: U8
-  ) \
-    severity activity low \
-    format "{x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x} {x}"
-
-  @ Parameters
-  param maxIterations: U32 default 100 id 0x20 set opcode 0x21 save opcode 0x22
-
-  external param configFile: string id 0x30
-
-  @ Port instances
-  async input port dataIn: [10] DataPort priority 10 drop
-  output port dataOut: [5] DataPort
-
-  sync input port controlIn: ControlPort priority 5 assert
-
-  command recv port cmdRecv
-  command reg port cmdReg
-  telemetry port tlmOut
-  event port eventOut
-  time get port timeGet
-  param get port prmGet
-  param set port prmSet
-
-  @ Internal ports
-  internal port ProcessData(data: U32, sz: U32) priority 10 block
-
-  @ Port matching
-  match dataIn with dataOut
-
-  @ Container and record
-  product container TestContainer id 0x50 default priority 5
-  product record TestRecord: U32 array id 0x60
-
-  @ State machine
-  state machine TestSM
-  state machine instance smInst: TestSM priority 10 hook
-
-  @ Type definitions inside component
-  type LocalType = U32
-  array LocalArray = [3] F32 default 0.0
-  struct LocalStruct {
-    x: U32
-    y: F32
-    z: string
-  }
-  enum LocalEnum {
-    IDLE
-    RUNNING
-    STOPPED
-  } default IDLE
-
-  @ Constant definition
-  constant LOCAL_CONST = 42
+    @ Constant definition
+    constant LOCAL_CONST = 42
 }

--- a/fpp_format/tests/config.rs
+++ b/fpp_format/tests/config.rs
@@ -46,14 +46,14 @@ impl Drop for TempDir {
 const UNFORMATTED: &str = "module M {\nconstant x = 1\n}\n";
 
 #[test]
-fn default_indent_is_two_without_config() {
+fn default_indent_is_four_without_config() {
     let dir = TempDir::new("default");
     let file = dir.path().join("a.fpp");
     fs::write(&file, UNFORMATTED).unwrap();
 
     let status = Command::new(bin()).arg(&file).status().unwrap();
     assert!(status.success());
-    assert_eq!(indent_of(&fs::read_to_string(&file).unwrap()), 2);
+    assert_eq!(indent_of(&fs::read_to_string(&file).unwrap()), 4);
 }
 
 #[test]

--- a/fpp_format/tests/constant-align.ref.fpp
+++ b/fpp_format/tests/constant-align.ref.fpp
@@ -1,15 +1,15 @@
 module Constants {
-  constant a    = 1
-  constant bbbb = 2
-  constant cc   = 0x10
+    constant a    = 1
+    constant bbbb = 2
+    constant cc   = 0x10
 
-  @ A documented constant breaks the alignment run
-  constant dddddd = 4
-  constant e      = 5
+    @ A documented constant breaks the alignment run
+    constant dddddd = 4
+    constant e      = 5
 
-  enum E {
-    X   = 1
-    YYY = 22
-    Z   = 333
-  }
+    enum E {
+        X   = 1
+        YYY = 22
+        Z   = 333
+    }
 }

--- a/fpp_format/tests/enum-annotation-align.ref.fpp
+++ b/fpp_format/tests/enum-annotation-align.ref.fpp
@@ -1,29 +1,29 @@
 module M {
-  @ Enum constants carrying both `=` values and `@<` annotations must align
-  @ the `=` column and the `@<` column independently.
-  enum TransactionType: U8 {
-    BLOCK       = 0x0 @< One trigger required for each block transfer
-    BEAT        = 0x2 @< One trigger required for each beat transfer
-    TRANSACTION = 0x3 @< One trigger required for each transaction
-  }
+    @ Enum constants carrying both `=` values and `@<` annotations must align
+    @ the `=` column and the `@<` column independently.
+    enum TransactionType : U8 {
+        BLOCK       = 0x0  @< One trigger required for each block transfer
+        BEAT        = 0x2  @< One trigger required for each beat transfer
+        TRANSACTION = 0x3  @< One trigger required for each transaction
+    }
 
-  @ Varying value widths: the annotation column follows the widest value.
-  enum Widths {
-    A    = 0x0   @< first
-    BBBB = 0x200 @< second
-    C    = 0x1   @< third
-  }
+    @ Varying value widths: the annotation column follows the widest value.
+    enum Widths {
+        A    = 0x0    @< first
+        BBBB = 0x200  @< second
+        C    = 0x1    @< third
+    }
 
-  @ Enum without values still aligns the annotations alone.
-  enum NoValues {
-    OK        @< ok
-    BUS_ERROR @< error
-  }
+    @ Enum without values still aligns the annotations alone.
+    enum NoValues {
+        OK         @< ok
+        BUS_ERROR  @< error
+    }
 
-  @ Struct members align the `@<` annotation column too.
-  struct Writeback {
-    btctrl: U16   @< Block Transfer Control
-    btcnt: U16    @< Remaining beat count
-    descaddr: U32 @< Next descriptor address
-  }
+    @ Struct members align the `@<` annotation column too.
+    struct Writeback {
+        btctrl: U16    @< Block Transfer Control
+        btcnt: U16     @< Remaining beat count
+        descaddr: U32  @< Next descriptor address
+    }
 }

--- a/fpp_format/tests/expr-shift-sizeof.ref.fpp
+++ b/fpp_format/tests/expr-shift-sizeof.ref.fpp
@@ -1,7 +1,7 @@
 module M {
-  constant a = 1 << 4
-  constant b = 256 >> 2
-  constant c = 1 + 2 << 3 - 1
-  constant s = sizeof(U32)
-  constant t = sizeof(F64)
+    constant a = 1 << 4
+    constant b = 256 >> 2
+    constant c = 1 + 2 << 3 - 1
+    constant s = sizeof(U32)
+    constant t = sizeof(F64)
 }

--- a/fpp_format/tests/expressions.ref.fpp
+++ b/fpp_format/tests/expressions.ref.fpp
@@ -1,40 +1,40 @@
 @ Expression forms not covered by simple binary constants
 module Expressions {
-  @ Unary negation
-  constant neg = -42
+    @ Unary negation
+    constant neg = -42
 
-  @ Negation of a parenthesized sum
-  constant negSum = -(1 + 2)
+    @ Negation of a parenthesized sum
+    constant negSum = -(1 + 2)
 
-  @ Parenthesized precedence
-  constant grouped = (1 + 2) * (3 - 4)
+    @ Parenthesized precedence
+    constant grouped = (1 + 2) * (3 - 4)
 
-  @ Nested parens
-  constant nested = ((1))
+    @ Nested parens
+    constant nested = ((1))
 
-  @ Array literal expression
-  constant arr = [1, 2, 3]
+    @ Array literal expression
+    constant arr = [1, 2, 3]
 
-  @ Struct-value expression
-  constant pt = { x = 1, y = 2 }
+    @ Struct-value expression
+    constant pt = { x = 1, y = 2 }
 
-  @ Nested struct value
-  constant nestedStruct = { inner = { a = 1 }, flag = true }
+    @ Nested struct value
+    constant nestedStruct = { inner = { a = 1 }, flag = true }
 
-  @ Member access on a qualified identifier
-  constant member = A.B.value
+    @ Member access on a qualified identifier
+    constant member = A.B.value
 
-  @ Subscript expression
-  constant elem = data[2]
+    @ Subscript expression
+    constant elem = data[2]
 
-  @ Chained member and subscript
-  constant chained = a.b[0].c
+    @ Chained member and subscript
+    constant chained = a.b[0].c
 
-  @ Float and boolean literals
-  constant pi   = 3.14
-  constant flag = true
-  constant off  = false
+    @ Float and boolean literals
+    constant pi   = 3.14
+    constant flag = true
+    constant off  = false
 
-  @ String literal constant
-  constant greeting = "hello"
+    @ String literal constant
+    constant greeting = "hello"
 }

--- a/fpp_format/tests/formatter.rs
+++ b/fpp_format/tests/formatter.rs
@@ -120,6 +120,7 @@ fmt_test!(multiline_string_align, "multiline-string-align");
 fmt_test!(constant_align, "constant-align");
 fmt_test!(enum_annotation_align, "enum-annotation-align");
 fmt_test!(param_annotation, "param-annotation");
+fmt_test!(blank_lines, "blank-lines");
 
 #[test]
 fn component_inner() {

--- a/fpp_format/tests/instances-locate.ref.fpp
+++ b/fpp_format/tests/instances-locate.ref.fpp
@@ -1,33 +1,33 @@
 @ Component instances, init specifiers, and locate specifiers
 module Deployment {
-  @ Minimal instance
-  instance simpleInst: Comp base id 0x100
+    @ Minimal instance
+    instance simpleInst: Comp base id 0x100
 
-  @ Instance with every optional clause
-  instance fullInst: NS.Comp base id 0x200 \
-    type "SpecialType" \
-    at "path/to/file.fpp" \
-    queue size 10 \
-    stack size 4096 \
-    priority 5 \
-    cpu 1 {
-      phase Fpp.ToCpp.Phases.configObjects "code goes here"
-      phase Fpp.ToCpp.Phases.instances "more code"
-    }
+    @ Instance with every optional clause
+    instance fullInst: NS.Comp base id 0x200 \
+        type "SpecialType" \
+        at "path/to/file.fpp" \
+        queue size 10 \
+        stack size 4096 \
+        priority 5 \
+        cpu 1 {
+            phase Fpp.ToCpp.Phases.configObjects "code goes here"
+            phase Fpp.ToCpp.Phases.instances "more code"
+        }
 
-  @ Instance with just queue and stack
-  instance workerInst: Worker base id 0x300 queue size 20 stack size 8192
+    @ Instance with just queue and stack
+    instance workerInst: Worker base id 0x300 queue size 20 stack size 8192
 
-  @ Locate specifiers of each kind
-  locate component Foo at "components/Foo.fpp"
-  locate constant BAR at "constants/Bar.fpp"
-  locate instance baz at "instances/Baz.fpp"
-  locate port MyPort at "ports/MyPort.fpp"
-  locate type MyType at "types/MyType.fpp"
-  locate interface MyInterface at "interfaces/MyInterface.fpp"
-  locate state machine MySM at "sm/MySM.fpp"
-  locate system MySystem at "systems/MySystem.fpp"
+    @ Locate specifiers of each kind
+    locate component Foo at "components/Foo.fpp"
+    locate constant BAR at "constants/Bar.fpp"
+    locate instance baz at "instances/Baz.fpp"
+    locate port MyPort at "ports/MyPort.fpp"
+    locate type MyType at "types/MyType.fpp"
+    locate interface MyInterface at "interfaces/MyInterface.fpp"
+    locate state machine MySM at "sm/MySM.fpp"
+    locate system MySystem at "systems/MySystem.fpp"
 
-  @ System definition
-  system MySystem: NS.MyTopology
+    @ System definition
+    system MySystem: NS.MyTopology
 }

--- a/fpp_format/tests/interface-include.ref.fpp
+++ b/fpp_format/tests/interface-include.ref.fpp
@@ -1,26 +1,26 @@
 @ Interfaces, interface imports, and module-level includes
 module Interfaces {
-  @ Module-level include
-  include "common/Ports.fppi"
+    @ Module-level include
+    include "common/Ports.fppi"
 
-  @ Empty interface
-  interface EmptyInterface {
-  }
+    @ Empty interface
+    interface EmptyInterface {
+    }
 
-  @ Interface with imports and port instances
-  interface DataInterface {
-    @ Import another interface
-    import Base.CommonInterface
-    import OtherInterface
+    @ Interface with imports and port instances
+    interface DataInterface {
+        @ Import another interface
+        import Base.CommonInterface
+        import OtherInterface
 
-    @ Port instances inside the interface
-    async input port dataIn: DataPort
-    output port dataOut: DataPort
-  }
+        @ Port instances inside the interface
+        async input port dataIn: DataPort
+        output port dataOut: DataPort
+    }
 
-  @ Interface importing several
-  interface CombinedInterface {
-    import DataInterface
-    import Interfaces.EmptyInterface
-  }
+    @ Interface importing several
+    interface CombinedInterface {
+        import DataInterface
+        import Interfaces.EmptyInterface
+    }
 }

--- a/fpp_format/tests/multiline-string-align.ref.fpp
+++ b/fpp_format/tests/multiline-string-align.ref.fpp
@@ -1,25 +1,25 @@
 module DataProducts {
-  instance dpCat: Svc.DpCatalog base id 0x00000 \
-    queue size 10 {
-      phase Fpp.ToCpp.Phases.configComponents """
+    instance dpCat: Svc.DpCatalog base id 0x00000 \
+        queue size 10 {
+            phase Fpp.ToCpp.Phases.configComponents """
         Fw::FileNameString dpDir(DataProductsConfig::Paths::dpDir);
         DataProducts::dpCat.configure(&dpDir,1,dpState,0, DataProducts::Allocation::memAllocator);
         """
+        }
+
+    topology Subtopology {
+        instance dpCat
+        instance dpMgr
+
+        connections DataProducts {
+            dpMgr.bufferGetOut[0]   -> dpCat.bufferGetCallee
+            dpMgr.productSendOut[0] -> dpCat.bufferSendInFill
+            dpCat.dpWrittenOut      -> dpCat.addToCat
+        }
+
+        @ Input port for get requests
+        port productGetIn = dpMgr.productGetIn
+        @ Output port for responses
+        port productResponseOut = dpMgr.productResponseOut
     }
-
-  topology Subtopology {
-    instance dpCat
-    instance dpMgr
-
-    connections DataProducts {
-      dpMgr.bufferGetOut[0]   -> dpCat.bufferGetCallee
-      dpMgr.productSendOut[0] -> dpCat.bufferSendInFill
-      dpCat.dpWrittenOut      -> dpCat.addToCat
-    }
-
-    @ Input port for get requests
-    port productGetIn = dpMgr.productGetIn
-    @ Output port for responses
-    port productResponseOut = dpMgr.productResponseOut
-  }
 }

--- a/fpp_format/tests/multiple-definitions.ref.fpp
+++ b/fpp_format/tests/multiple-definitions.ref.fpp
@@ -1,11 +1,11 @@
 module F {
-  constant a = 1
-  constant b = 2
-  constant c = 3
-  type MyType = U32
-  enum Color {
-    RED @< Color Red
-    GREEN
-    BLUE
-  }
+    constant a = 1
+    constant b = 2
+    constant c = 3
+    type MyType = U32
+    enum Color {
+        RED  @< Color Red
+        GREEN
+        BLUE
+    }
 }

--- a/fpp_format/tests/nested-module.ref.fpp
+++ b/fpp_format/tests/nested-module.ref.fpp
@@ -1,6 +1,6 @@
 module Outer {
-  module Inner {
-    constant x = 10
-  }
-  constant y = 20
+    module Inner {
+        constant x = 10
+    }
+    constant y = 20
 }

--- a/fpp_format/tests/param-annotation.ref.fpp
+++ b/fpp_format/tests/param-annotation.ref.fpp
@@ -1,16 +1,16 @@
 module Fw {
-  @ Port for sending a buffer
-  port BufferSend(
-    @ The buffer
-    ref fwBuffer: Fw.Buffer
-  )
+    @ Port for sending a buffer
+    port BufferSend(
+        @ The buffer
+        ref fwBuffer: Fw.Buffer
+    )
 
-  @ Port for getting a buffer
-  port BufferGet(
-    @ The requested size
-    $size: FwSizeType
-  ) -> Fw.Buffer
+    @ Port for getting a buffer
+    port BufferGet(
+        @ The requested size
+        $size: FwSizeType
+    ) -> Fw.Buffer
 
-  @ A port whose params carry no annotations still flattens
-  port Plain(a: U32, b: U32)
+    @ A port whose params carry no annotations still flattens
+    port Plain(a: U32, b: U32)
 }

--- a/fpp_format/tests/port.ref.fpp
+++ b/fpp_format/tests/port.ref.fpp
@@ -1,20 +1,20 @@
 @ Module with port definitions
 module Ports {
-  @ Simple port without return
-  port DataPort(value: U32, timestamp: F32)
+    @ Simple port without return
+    port DataPort(value: U32, timestamp: F32)
 
-  @ Port with return type
-  port ComputePort(input1: F32, input2: F32) -> F32
+    @ Port with return type
+    port ComputePort(input1: F32, input2: F32) -> F32
 
-  @ Port without parameters
-  port SimpleSignalPort
+    @ Port without parameters
+    port SimpleSignalPort
 
-  @ Port with single parameter
-  port NotifyPort(msg: string)
+    @ Port with single parameter
+    port NotifyPort(msg: string)
 
-  @ Port with ref parameter
-  port RefPort(ref buffer: U32)
+    @ Port with ref parameter
+    port RefPort(ref buffer: U32)
 
-  @ Port with multiple params and return
-  port ComplexPort(a: U32, b: F32, c: string) -> U32
+    @ Port with multiple params and return
+    port ComplexPort(a: U32, b: F32, c: string) -> U32
 }

--- a/fpp_format/tests/simple-module.ref.fpp
+++ b/fpp_format/tests/simple-module.ref.fpp
@@ -1,3 +1,3 @@
 module F {
-  constant a = 1
+    constant a = 1
 }

--- a/fpp_format/tests/state-machine-defs.ref.fpp
+++ b/fpp_format/tests/state-machine-defs.ref.fpp
@@ -1,26 +1,26 @@
 module M {
-  state machine S {
-    type T
-    type Alias = U32
-    array Arr = [3] U32
-    constant c = 1
-    enum E {
-      A
-      B
+    state machine S {
+        type T
+        type Alias = U32
+        array Arr = [3] U32
+        constant c = 1
+        enum E {
+            A
+            B
+        }
+        struct St {
+            x: U32
+        }
+        signal sig: E
+        action act: Arr
+        guard g
+        initial enter Idle
+        state Idle {
+            on sig enter Run
+        }
+        state Run {
+            entry do { act }
+            exit do { act }
+        }
     }
-    struct St {
-      x: U32
-    }
-    signal sig: E
-    action act: Arr
-    guard g
-    initial enter Idle
-    state Idle {
-      on sig enter Run
-    }
-    state Run {
-      entry do { act }
-      exit do { act }
-    }
-  }
 }

--- a/fpp_format/tests/state-machine.fpp
+++ b/fpp_format/tests/state-machine.fpp
@@ -45,7 +45,7 @@ module StateMachines {
         state Waiting {
             @ Choice definition
             choice CheckCondition {
-                if isReady enter Active else enter Idle
+                if isReady enter Active else enter Idle @< choice transition annotation
             }
 
             @ Transition to choice

--- a/fpp_format/tests/state-machine.ref.fpp
+++ b/fpp_format/tests/state-machine.ref.fpp
@@ -1,98 +1,98 @@
 @ State machine test
 module StateMachines {
-  @ Simple state machine
-  state machine SimpleSM {
-    @ Signal definitions
-    signal tick
-    signal dataReady: U32
-    signal timeout
+    @ Simple state machine
+    state machine SimpleSM {
+        @ Signal definitions
+        signal tick
+        signal dataReady: U32
+        signal timeout
 
-    @ Action definitions
-    action processData
-    action logError: U32
-    action reset
+        @ Action definitions
+        action processData
+        action logError: U32
+        action reset
 
-    @ Guard definitions
-    guard isReady
-    guard hasData: U32
+        @ Guard definitions
+        guard isReady
+        guard hasData: U32
 
-    @ Initial transition
-    initial enter Idle
+        @ Initial transition
+        initial enter Idle
 
-    @ States
-    state Idle
+        @ States
+        state Idle
 
-    state Active {
-      entry do { processData }
-      exit do { reset, logError }
+        state Active {
+            entry do { processData }
+            exit do { reset, logError }
 
-      @ Nested states
-      state Processing
+            @ Nested states
+            state Processing
 
-      @ Initial transition for nested state
-      initial do { processData } enter Processing
+            @ Initial transition for nested state
+            initial do { processData } enter Processing
 
-      @ Transitions
-      on tick enter Idle
-      on dataReady if isReady do { processData } enter Processing
-      on timeout if hasData enter Idle
+            @ Transitions
+            on tick enter Idle
+            on dataReady if isReady do { processData } enter Processing
+            on timeout if hasData enter Idle
+        }
+
+        @ State with choice
+        state Waiting {
+            @ Choice definition
+            choice CheckCondition {
+                if isReady enter Active else enter Idle  @< choice transition annotation
+            }
+
+            @ Transition to choice
+            on tick enter CheckCondition
+            on dataReady do { processData }
+        }
     }
 
-    @ State with choice
-    state Waiting {
-      @ Choice definition
-      choice CheckCondition {
-        if isReady enter Active else enter Idle
-      }
+    @ Complex state machine
+    state machine ComplexSM {
+        signal s1
+        signal s2: U32
+        signal s3
 
-      @ Transition to choice
-      on tick enter CheckCondition
-      on dataReady do { processData }
+        action a1
+        action a2: F32
+        action a3
+
+        guard g1
+        guard g2: bool
+
+        initial do { a1, a2 } enter S1
+
+        choice C1 {
+            if g1 do { a1 } enter S2 else do { a2 } enter S3
+        }
+
+        choice C2 {
+            if g2 do { a1, a2, a3 } enter S2 else enter S3
+        }
+
+        choice C3 {
+            if g2 do { a1a2a3 } enter S2 else enter S3
+        }
+
+        choice RESUME {
+            if pendingHostFunction do {
+                dispatchPendingHostFunction
+            } enter AWAITING_RESPONSE else enter SPINNING
+        }
+
+        state S1 {
+            on s1 if g1 do { a1 } enter C1
+            on s2 enter S2
+        }
+
+        state S2
+
+        state S3 {
+            initial enter S2
+        }
     }
-  }
-
-  @ Complex state machine
-  state machine ComplexSM {
-    signal s1
-    signal s2: U32
-    signal s3
-
-    action a1
-    action a2: F32
-    action a3
-
-    guard g1
-    guard g2: bool
-
-    initial do { a1, a2 } enter S1
-
-    choice C1 {
-      if g1 do { a1 } enter S2 else do { a2 } enter S3
-    }
-
-    choice C2 {
-      if g2 do { a1, a2, a3 } enter S2 else enter S3
-    }
-
-    choice C3 {
-      if g2 do { a1a2a3 } enter S2 else enter S3
-    }
-
-    choice RESUME {
-      if pendingHostFunction do {
-        dispatchPendingHostFunction
-      } enter AWAITING_RESPONSE else enter SPINNING
-    }
-
-    state S1 {
-      on s1 if g1 do { a1 } enter C1
-      on s2 enter S2
-    }
-
-    state S2
-
-    state S3 {
-      initial enter S2
-    }
-  }
 }

--- a/fpp_format/tests/topology-extra.ref.fpp
+++ b/fpp_format/tests/topology-extra.ref.fpp
@@ -1,43 +1,43 @@
 @ Topology constructs not in the main topology fixture
 module TopExtra {
-  @ Topology implementing interfaces
-  topology Impl implements Base.TopoA, Base.TopoB {
-    instance compA
-    instance compB
-  }
-
-  @ Pattern connections with explicit target lists
-  topology Patterns {
-    instance central
-    instance a
-    instance b
-
-    @ Command pattern targeting a specific list of instances
-    command connections instance central {
-      a
-      b
+    @ Topology implementing interfaces
+    topology Impl implements Base.TopoA, Base.TopoB {
+        instance compA
+        instance compB
     }
 
-    @ Health pattern with targets
-    health connections instance central {
-      a
-      b
-    }
+    @ Pattern connections with explicit target lists
+    topology Patterns {
+        instance central
+        instance a
+        instance b
 
-    @ Param pattern with targets
-    param connections instance central {
-      a
-    }
+        @ Command pattern targeting a specific list of instances
+        command connections instance central {
+            a
+            b
+        }
 
-    @ Telemetry packet set with includes and omit
-    telemetry packets PktSet {
-      include "packets/Common.fppi"
-      packet Pkt1 id 1 group 2 {
-        include "packets/Ch.fppi"
-        central.channelA
-      }
-    } omit {
-      central.debugChannel
+        @ Health pattern with targets
+        health connections instance central {
+            a
+            b
+        }
+
+        @ Param pattern with targets
+        param connections instance central {
+            a
+        }
+
+        @ Telemetry packet set with includes and omit
+        telemetry packets PktSet {
+            include "packets/Common.fppi"
+            packet Pkt1 id 1 group 2 {
+                include "packets/Ch.fppi"
+                central.channelA
+            }
+        } omit {
+            central.debugChannel
+        }
     }
-  }
 }

--- a/fpp_format/tests/topology.ref.fpp
+++ b/fpp_format/tests/topology.ref.fpp
@@ -1,66 +1,66 @@
 @ Test topology
 module TestTopology {
-  @ Deployment topology
-  deployment topology DeploymentTopology {
-    instance compA
-  }
-
-  topology RefTopology {
-    @ Instance imports and definitions
-    import SubModule.SubTopology
-    import AnotherModule.Topology
-
-    instance compA
-    instance compB
-    instance compC
-
-    @ Port exports
-    port exportedPort = compA.outputPort
-
-    @ Pattern connection graphs
-    command connections instance compA
-
-    event connections instance compB
-
-    telemetry connections instance compC
-
-    time connections instance compA
-
-    param connections instance compB
-
-    health connections instance compA
-
-    text event connections instance compB
-
-    @ Direct connections
-    connections MainConnections {
-      compA.dataOut    -> compB.dataIn
-      compB.controlOut -> compC.controlIn
-      compC.statusOut  -> compA.statusIn
-
-      compA.portArray[0] -> compB.singlePort
-      compB.dataOut[1]   -> compC.dataIn[1]
-
-      unmatched compA.optionalOut -> compC.optionalIn
+    @ Deployment topology
+    deployment topology DeploymentTopology {
+        instance compA
     }
 
-    connections SecondaryConnections {
-      compA.cmdOut -> compB.cmdIn
-    }
+    topology RefTopology {
+        @ Instance imports and definitions
+        import SubModule.SubTopology
+        import AnotherModule.Topology
 
-    @ Telemetry packet set
-    telemetry packets TestPackets {
-      packet P1 group 1 {
-        compA.channel1
-        compB.channel2
-        compC.channel3
-      }
-      packet P2 group 2 {
-        compA.tempChannel
-      }
-    } omit {
-      compA.debugChannel
-      compB.internalChannel
+        instance compA
+        instance compB
+        instance compC
+
+        @ Port exports
+        port exportedPort = compA.outputPort
+
+        @ Pattern connection graphs
+        command connections instance compA
+
+        event connections instance compB
+
+        telemetry connections instance compC
+
+        time connections instance compA
+
+        param connections instance compB
+
+        health connections instance compA
+
+        text event connections instance compB
+
+        @ Direct connections
+        connections MainConnections {
+            compA.dataOut    -> compB.dataIn
+            compB.controlOut -> compC.controlIn
+            compC.statusOut  -> compA.statusIn
+
+            compA.portArray[0] -> compB.singlePort
+            compB.dataOut[1]   -> compC.dataIn[1]
+
+            unmatched compA.optionalOut -> compC.optionalIn
+        }
+
+        connections SecondaryConnections {
+            compA.cmdOut -> compB.cmdIn
+        }
+
+        @ Telemetry packet set
+        telemetry packets TestPackets {
+            packet P1 group 1 {
+                compA.channel1
+                compB.channel2
+                compC.channel3
+            }
+            packet P2 group 2 {
+                compA.tempChannel
+            }
+        } omit {
+            compA.debugChannel
+            compB.internalChannel
+        }
     }
-  }
 }

--- a/fpp_format/tests/type-defs.ref.fpp
+++ b/fpp_format/tests/type-defs.ref.fpp
@@ -1,52 +1,52 @@
 @ Type-definition variants: abstract types, aliases, enum rep types, string sizes
 module Types {
-  @ Abstract type (no `=`)
-  type AbstractType
+    @ Abstract type (no `=`)
+    type AbstractType
 
-  @ Type alias to a primitive
-  type AliasU32 = U32
+    @ Type alias to a primitive
+    type AliasU32 = U32
 
-  @ Type alias to a qualified name
-  type AliasQual = NS.SomeType
+    @ Type alias to a qualified name
+    type AliasQual = NS.SomeType
 
-  @ Type alias to a sized string
-  type SizedStringAlias = string size 40
+    @ Type alias to a sized string
+    type SizedStringAlias = string size 40
 
-  @ Enum with explicit representation type
-  enum RepEnum: U8 {
-    A = 0
-    B = 1
-    C = 2
-  }
+    @ Enum with explicit representation type
+    enum RepEnum : U8 {
+        A = 0
+        B = 1
+        C = 2
+    }
 
-  @ Enum with rep type and default
-  enum DefaultedEnum: I32 {
-    X
-    Y
-    Z
-  } default Y
+    @ Enum with rep type and default
+    enum DefaultedEnum : I32 {
+        X
+        Y
+        Z
+    } default Y
 
-  @ Struct with a sized-string field
-  struct Message {
-    header: U32
-    body: string size 128
-  }
+    @ Struct with a sized-string field
+    struct Message {
+        header: U32
+        body: string size 128
+    }
 
-  @ Array of sized strings
-  array Names = [4] string size 16
+    @ Array of sized strings
+    array Names = [4] string size 16
 
-  @ Array with default and format together
-  array Levels = [3] U8 default 0 format "level {}"
+    @ Array with default and format together
+    array Levels = [3] U8 default 0 format "level {}"
 
-  @ Dictionary-prefixed definitions
-  dictionary constant DICT_CONST = 7
-  dictionary type DictType = U32
-  dictionary enum DictEnum {
-    A
-    B
-  }
-  dictionary array DictArray = [2] U32
-  dictionary struct DictStruct {
-    x: U32
-  }
+    @ Dictionary-prefixed definitions
+    dictionary constant DICT_CONST = 7
+    dictionary type DictType = U32
+    dictionary enum DictEnum {
+        A
+        B
+    }
+    dictionary array DictArray = [2] U32
+    dictionary struct DictStruct {
+        x: U32
+    }
 }


### PR DESCRIPTION
After we reviewed the current formatter output we found some minor issues which prompted this pass. The following changes were made:

- Default to indent 4
- Two spaces before @<
- Keep blank start/end of module (and other) definitions
- Add space before `:` in enum serial type
