### PR TITLE
Match comments exactly to Scala

### DIFF
--- a/fpp_analysis/src/analysis.rs
+++ b/fpp_analysis/src/analysis.rs
@@ -8,92 +8,93 @@ use fpp_core::{SourceFile, Span, Spanned};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::sync::Arc;
 
+/// The analysis data structure
 #[derive(Debug)]
 pub struct Analysis {
-    /** The mapping from symbols to their parent symbols */
+    /// The mapping from symbols to their parent symbols
     pub parent_symbol_map: HashMap<Symbol, Symbol>,
-    /** The outermost scope */
+    /// The outermost scope
     pub global_scope: Scope,
-    /** The mapping from symbols with scopes to their scopes */
+    /// The mapping from symbols with scopes to their scopes
     pub symbol_scope_map: HashMap<Symbol, Scope>,
-    /** The mapping from definition node ID to their entered symbol */
+    /// The mapping from definition node ID to their entered symbol
     pub symbol_map: HashMap<fpp_core::Node, Symbol>,
-    /** The mapping from uses (by node ID) to their definitions */
+    /// The mapping from uses (by node ID) to their definitions
     pub use_def_map: HashMap<fpp_core::Node, Symbol>,
-    /** The list of use-def matchings on the current use-def path.
-     *  Used during cycle analysis. */
+    /// The list of use-def matchings on the current use-def path.
+    /// Used during cycle analysis.
     pub use_def_matching_list: Vec<UseDefMatching>,
-    /** The set of symbols visited so far */
+    /// The set of symbols visited so far
     pub visited_symbol_set: HashSet<Symbol>,
-    /** The set of symbols on the current use-def path.
-     *  Used during cycle analysis. */
+    /// The set of symbols on the current use-def path.
+    /// Used during cycle analysis.
     pub use_def_symbol_set: HashSet<Symbol>,
-    /** The current parent symbol */
+    /// The current parent symbol
     pub parent_symbol: Option<Symbol>,
-    /** The current nested scope for symbol lookup */
+    /// The current nested scope for symbol lookup
     pub nested_scope: NestedScope,
-    /** The mapping from included files `.fppi` to their context they were included in */
+    /// The mapping from included files `.fppi` to their context they were included in
     pub include_context_map: HashMap<SourceFile, fpp_parser::IncludeParentKind>,
-    /** The mapping from type and constant symbols, expressions,
-     *  and type names to their types */
+    /// The mapping from type and constant symbols, expressions,
+    /// and type names to their types
     pub type_map: HashMap<fpp_core::Node, Arc<Type>>,
-    /** The mapping from constant symbols and expressions to their values. */
+    /// The mapping from constant symbols and expressions to their values.
     pub value_map: HashMap<fpp_core::Node, Value>,
-    /** The F Prime framework definitions found during analysis. */
+    /// The F Prime framework definitions found during analysis.
     pub framework_definitions: FrameworkDefinitions,
-    /** The interface currently being analyzed. */
+    /// The interface currently being analyzed.
     pub interface: Option<Interface>,
-    /** The mapping from interface symbols to their resolved interfaces. */
+    /// The mapping from interface symbols to their resolved interfaces.
     pub interface_map: HashMap<Symbol, Interface>,
-    /** The component currently being analyzed. */
+    /// The component currently being analyzed.
     pub component: Option<crate::semantics::Component>,
-    /** The mapping from component symbols to their completed components. */
+    /// The mapping from component symbols to their completed components.
     pub component_map: HashMap<Symbol, crate::semantics::Component>,
-    /** The component instance currently being analyzed. */
+    /// The component instance currently being analyzed.
     pub component_instance: Option<crate::semantics::ComponentInstance>,
-    /** The mapping from component instance symbols to their instances. */
+    /// The mapping from component instance symbols to their instances.
     pub component_instance_map: HashMap<Symbol, crate::semantics::ComponentInstance>,
-    /** The topology currently being analyzed. */
+    /// The topology currently being analyzed.
     pub topology: Option<crate::semantics::Topology>,
-    /** The mapping from topology symbols to their partially resolved topologies. */
+    /// The mapping from topology symbols to their partially resolved topologies.
     pub partial_topology_map: HashMap<Symbol, crate::semantics::Topology>,
-    /** The mapping from topology symbols to their fully resolved topologies. */
+    /// The mapping from topology symbols to their fully resolved topologies.
     pub topology_map: HashMap<Symbol, crate::semantics::Topology>,
-    /** The mapping from system symbols to their resolved systems. */
+    /// The mapping from system symbols to their resolved systems.
     pub system_map: HashMap<Symbol, crate::semantics::FppSystem>,
-    /** The mapping from (location specifier kind, qualified name) to the
-     *  location specifier that named it. */
+    /// The mapping from (location specifier kind, qualified name) to the
+    /// location specifier that named it.
     pub location_specifier_map: HashMap<(fpp_ast::SpecLocKind, String), SpecLocEntry>,
-    /** The list of enclosing scope (module) names on the current path. */
+    /// The list of enclosing scope (module) names on the current path.
     pub scope_name_list: Vec<String>,
-    /** The mapping from state machine symbols to their analyzed state machines. */
+    /// The mapping from state machine symbols to their analyzed state machines.
     pub state_machine_map: HashMap<Symbol, crate::semantics::state_machine::StateMachine>,
-    /** The set of symbols marked as dictionary definitions and validated by
-     *  `CheckDictionaryDefs`. */
+    /// The set of symbols marked as dictionary definitions and validated by
+    /// `CheckDictionaryDefs`.
     pub dictionary_symbol_set: HashSet<Symbol>,
 
-    /** Map from an AST node id to the implied uses of FPP symbols at that node.
-     *  Populated by `ConstructImpliedUseMap` and consumed by the use-analysis
-     *  passes (`CheckUses`, `CheckUseDefCycles`). */
+    /// Map from an AST node id to the implied uses of FPP symbols at that node.
+    /// Populated by `ConstructImpliedUseMap` and consumed by the use-analysis
+    /// passes (`CheckUses`, `CheckUseDefCycles`).
     pub implied_use_map: HashMap<fpp_core::Node, ImpliedUseSet>,
 
-    /** The shared "unknown" type standing in for a type use that failed to
-     *  resolve. Created lazily on first use so that `CheckTypeUses` can give
-     *  every type name an entry in `type_map`, letting later passes read a
-     *  resolved type without handling the unresolved case. */
+    /// The shared "unknown" type standing in for a type use that failed to
+    /// resolve. Created lazily on first use so that `CheckTypeUses` can give
+    /// every type name an entry in `type_map`, letting later passes read a
+    /// resolved type without handling the unresolved case.
     unknown_type: Option<Arc<Type>>,
 }
 
 /// A recorded location specifier, keyed in `location_specifier_map`.
 #[derive(Debug, Clone)]
 pub struct SpecLocEntry {
-    /** Span of the location specifier statement */
+    /// Span of the location specifier statement
     pub spec_span: Span,
-    /** Span of the file string literal (error location + base for path resolution) */
+    /// Span of the file string literal (error location + base for path resolution)
     pub file_span: Span,
-    /** The specified (relative) path string */
+    /// The specified (relative) path string
     pub file_value: String,
-    /** Whether this is a dictionary specifier */
+    /// Whether this is a dictionary specifier
     pub is_dictionary_def: bool,
 }
 

--- a/fpp_analysis/src/analyzers/analyzer.rs
+++ b/fpp_analysis/src/analyzers/analyzer.rs
@@ -1,6 +1,7 @@
 use fpp_ast::{Node, Visitor};
 use std::ops::ControlFlow;
 
+/// A generic analysis visitor
 pub trait Analyzer<'ast, V: Visitor<'ast>> {
     fn visit(&self, visitor: &V, a: &mut V::State, node: Node<'ast>) -> ControlFlow<V::Break>;
 }

--- a/fpp_analysis/src/analyzers/basic_use_analyzer.rs
+++ b/fpp_analysis/src/analyzers/basic_use_analyzer.rs
@@ -10,7 +10,7 @@ use std::ops::{ControlFlow, Deref};
 /// An extension of the standard [Visitor] trait that allows analyzing uses of symbols
 /// [BasicUseAnalyzer] or [UseAnalyzer] should be used in your pass for this to work properly
 pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
-    /** A use of a component definition */
+    /// A use of a component definition
     fn component_use(
         &self,
         a: &mut Self::State,
@@ -23,7 +23,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** A use of an interface instance (topology def or component instance def) */
+    /// A use of an interface instance (topology def or component instance def)
     fn interface_instance_use(
         &self,
         a: &mut Self::State,
@@ -36,7 +36,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** A use of a constant definition or enumerated constant definition */
+    /// A use of a constant definition or enumerated constant definition
     fn constant_use(
         &self,
         a: &mut Self::State,
@@ -49,7 +49,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** A use of a port definition */
+    /// A use of a port definition
     fn port_use(
         &self,
         a: &mut Self::State,
@@ -62,7 +62,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** An implied use of a port definition (from a special port instance) */
+    /// An implied use of a port definition (from a special port instance)
     fn implied_port_use(
         &self,
         a: &mut Self::State,
@@ -72,7 +72,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         self.port_use(a, node, name)
     }
 
-    /** An implied use of a type definition (e.g. `FwSizeStoreType` for strings) */
+    /// An implied use of a type definition (e.g. `FwSizeStoreType` for strings)
     fn implied_type_use(
         &self,
         a: &mut Self::State,
@@ -85,8 +85,8 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** An implied use of a constant definition (e.g. `FW_FIXED_LENGTH_STRING_SIZE`
-     * for default-size strings) */
+    /// An implied use of a constant definition (e.g. `FW_FIXED_LENGTH_STRING_SIZE`
+    /// for default-size strings)
     fn implied_constant_use(
         &self,
         a: &mut Self::State,
@@ -99,7 +99,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** A use of an interface definition */
+    /// A use of an interface definition
     fn interface_use(
         &self,
         a: &mut Self::State,
@@ -112,7 +112,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** A use of a type definition */
+    /// A use of a type definition
     fn type_use(
         &self,
         a: &mut Self::State,
@@ -125,7 +125,7 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
         ControlFlow::Continue(())
     }
 
-    /** A use of a state machine definition*/
+    /// A use of a state machine definition
     fn state_machine_use(
         &self,
         a: &mut Self::State,
@@ -139,6 +139,8 @@ pub trait UseAnalysisPass<'ast, S: NestedScopeState>: Visitor<'ast, State = S> {
     }
 }
 
+/// Basic use analysis
+/// Assumes all qualified identifiers are constant uses
 pub struct BasicUseAnalyzer<'ast, S: NestedScopeState, V: UseAnalysisPass<'ast, S>> {
     super_: NestedAnalyzer<'ast, S, V>,
     phantom_data: PhantomData<S>,
@@ -160,6 +162,7 @@ impl<'ast, S: NestedScopeState, V: UseAnalysisPass<'ast, S>> BasicUseAnalyzer<'a
         }
     }
 
+    /// Gets a qualified name from a dot expression
     pub(crate) fn expr_to_qualified_name(&self, e: &Expr) -> Option<QualifiedName> {
         fn name_opt(e: &Expr, mut qualifier: VecDeque<String>) -> Option<QualifiedName> {
             match &e.kind {
@@ -189,6 +192,7 @@ impl<'ast, S: NestedScopeState, V: UseAnalysisPass<'ast, S>> Analyzer<'ast, V>
                 ci.walk(a, visitor)
             }
             Node::DefTopology(t) => {
+                // Visit port interface uses in the implements clause
                 for i in &t.implements {
                     visitor.interface_use(a, i, i.into())?;
                 }

--- a/fpp_analysis/src/analyzers/nested_analyzer.rs
+++ b/fpp_analysis/src/analyzers/nested_analyzer.rs
@@ -75,9 +75,13 @@ impl<'ast, S: NestedScopeState, V: Visitor<'ast, State = S>> Analyzer<'ast, V>
 {
     fn visit(&self, visitor: &V, a: &mut V::State, node: Node<'ast>) -> ControlFlow<V::Break> {
         match node {
+            // Analyze component members
             Node::DefComponent(def) => self.walk_symbol(visitor, a, a.get_symbol(def), node),
+            // Analyze enum constants
             Node::DefEnum(def) => self.walk_symbol(visitor, a, a.get_symbol(def), node),
+            // Visit translation unit members and module members
             Node::DefModule(def) => self.walk_symbol(visitor, a, a.get_symbol(def), node),
+            // Analyze state machine members
             Node::DefStateMachine(def) => self.walk_symbol(visitor, a, a.get_symbol(def), node),
             _ => match self.mode {
                 NestedAnalyzerMode::SHALLOW => ControlFlow::Continue(()),

--- a/fpp_analysis/src/analyzers/state_machine/state_machine_analysis_visitor.rs
+++ b/fpp_analysis/src/analyzers/state_machine/state_machine_analysis_visitor.rs
@@ -59,15 +59,14 @@ pub trait StateMachineAnalysisVisitor {
         self.default(sma)
     }
 
-    /// Analyze a state definition. The default behavior comes from
-    /// `StateAnalyzer`: push the state name onto the scope name list, visit
-    /// the members, and restore the scope name list.
+    /// Analyze a state definition: push the state name onto the scope name
+    /// list, visit the members, and restore the scope name list.
     fn def_state(&self, sma: &mut StateMachineAnalysis, node: &DefState) -> SmResult {
         self.state_analyzer_def_state(sma, node)
     }
 
-    /// The `StateAnalyzer` implementation of `def_state`, available to
-    /// passes that override `def_state` and need to call `super`.
+    /// The default implementation of `def_state`, available to passes that
+    /// override `def_state` and need to invoke the default behavior directly.
     fn state_analyzer_def_state(
         &self,
         sma: &mut StateMachineAnalysis,

--- a/fpp_analysis/src/analyzers/use_analyzer.rs
+++ b/fpp_analysis/src/analyzers/use_analyzer.rs
@@ -5,6 +5,8 @@ use crate::semantics::Symbol;
 use fpp_ast::{AstNode, ExprKind, Node, Visitable};
 use std::ops::ControlFlow;
 
+/// Analyze uses
+/// This analyzer assumes that CheckUses has already been run to populate the use-def map
 pub struct UseAnalyzer<'ast, V: UseAnalysisPass<'ast, Analysis>> {
     super_: BasicUseAnalyzer<'ast, Analysis, V>,
 }
@@ -30,6 +32,7 @@ impl<'ast, V: UseAnalysisPass<'ast, Analysis>> Analyzer<'ast, V> for UseAnalyzer
                 match &expr.kind {
                     ExprKind::Dot { e, .. } => {
                         match a.use_def_map.get(&expr.id()) {
+                            // expr is a use, so it must be a constant use
                             Some(Symbol::Constant(_) | Symbol::EnumConstant(_)) => {
                                 let use_name = self
                                     .super_
@@ -42,6 +45,7 @@ impl<'ast, V: UseAnalysisPass<'ast, Analysis>> Analyzer<'ast, V> for UseAnalyzer
                                 // Analyze the left-hand expression representing the struct value
                                 e.visit(a, visitor)
                             }
+                            // Some other kind of symbol, which should not occur here
                             Some(_) => ControlFlow::Continue(()),
                         }
                     }

--- a/fpp_analysis/src/errors.rs
+++ b/fpp_analysis/src/errors.rs
@@ -7,8 +7,10 @@ pub struct SymbolUse {
     pub use_loc: Span,
 }
 
+/// A semantic error
 #[derive(Debug)]
 pub enum SemanticError {
+    /// Redefined symbol
     RedefinedSymbol {
         /// Name of the symbol being redefined
         name: String,
@@ -17,36 +19,43 @@ pub enum SemanticError {
         /// Location of the previous symbol that is clashing
         prev_loc: Span,
     },
+    /// Undefined symbol
     UndefinedSymbol {
         ng: String,
         name: String,
         loc: Span,
     },
+    /// Use-def cycle
     UseDefCycle {
         loc: Span,
         cycle: Vec<SymbolUse>,
     },
+    /// Invalid symbol
     InvalidSymbol {
         symbol_name: String,
         msg: String,
         loc: Span,
         def_loc: Span,
     },
+    /// Invalid type
     InvalidType {
         loc: Span,
         msg: String,
     },
+    /// Invalid qualifier
     InvalidQualifier {
         loc: Span,
         msg: String,
         def_loc: Span,
         def_msg: String,
     },
+    /// Duplicate struct member
     DuplicateStructMember {
         name: String,
         loc: Span,
         prev_loc: Span,
     },
+    /// Duplicate parameter
     DuplicateParameter {
         name: String,
         loc: Span,
@@ -57,6 +66,7 @@ pub enum SemanticError {
         msg: String,
         err: Box<TypeConversionError>,
     },
+    /// Empty array
     EmptyArray {
         loc: Span,
     },
@@ -66,22 +76,27 @@ pub enum SemanticError {
     EnumConstantShouldBeExplicit {
         loc: Span,
     },
+    /// Duplicate enum value
     DuplicateEnumConstant {
         value: i128,
         loc: Span,
         prev_loc: Span,
     },
+    /// Invalid integer value
     InvalidIntValue {
         loc: Span,
         v: Option<i128>,
         msg: String,
     },
+    /// Division by zero
     DivisionByZero {
         loc: Span,
     },
+    /// Invalid shift amount
     InvalidShiftAmount {
         loc: Span,
     },
+    /// A member-selection expression names a member that does not exist on the type
     InvalidTypeForMemberSelection {
         loc: Span,
         member: String,
@@ -107,30 +122,37 @@ pub enum SemanticError {
         value_size: usize,
         type_size: i128,
     },
+    /// Invalid array size
     InvalidArraySize {
         loc: Span,
         size: i128,
     },
+    /// Invalid priority specifier
     InvalidPriority {
         loc: Span,
     },
+    /// Invalid queue full specifier
     InvalidQueueFull {
         loc: Span,
     },
+    /// Invalid special port
     InvalidSpecialPort {
         loc: Span,
         msg: String,
     },
+    /// Invalid port instance
     InvalidPortInstance {
         loc: Span,
         msg: String,
         def_loc: Span,
     },
+    /// Duplicate interface
     DuplicateInterface {
         name: String,
         loc: Span,
         prev_loc: Span,
     },
+    /// Duplicate port instance
     DuplicatePortInstance {
         name: String,
         loc: Span,
@@ -138,49 +160,59 @@ pub enum SemanticError {
         prev_loc: Span,
         prev_import_locs: Vec<Span>,
     },
+    /// Error while importing an interface
     InterfaceImport {
         loc: Span,
         inner: Box<SemanticError>,
     },
+    /// Passive async input
     PassiveAsync {
         loc: Span,
         import_locs: Vec<Span>,
     },
+    /// Duplicate opcode value
     DuplicateOpcodeValue {
         value: String,
         loc: Span,
         prev_loc: Span,
     },
+    /// Duplicate ID value
     DuplicateIdValue {
         value: String,
         loc: Span,
         prev_loc: Span,
     },
+    /// Duplicate state machine instance
     DuplicateStateMachineInstance {
         name: String,
         loc: Span,
         prev_loc: Span,
     },
+    /// Duplicate telemetry channel limit
     DuplicateLimit {
         loc: Span,
         prev_loc: Span,
     },
+    /// Duplicate name in dictionary
     DuplicateDictionaryName {
         kind: String,
         name: String,
         loc: Span,
         prev_loc: Span,
     },
+    /// Duplicate init specifier
     DuplicateInitSpecifier {
         phase: i128,
         loc: Span,
         prev_loc: Span,
     },
+    /// Missing port
     MissingPort {
         loc: Span,
         spec_msg: String,
         port_msg: String,
     },
+    /// Missing async input
     MissingAsync {
         kind: String,
         loc: Span,
@@ -188,36 +220,44 @@ pub enum SemanticError {
     PassiveStateMachine {
         loc: Span,
     },
+    /// Invalid data products
     InvalidDataProducts {
         loc: Span,
         msg: String,
     },
+    /// Invalid command
     InvalidCommand {
         loc: Span,
         msg: String,
     },
+    /// Invalid event
     InvalidEvent {
         loc: Span,
         msg: String,
     },
+    /// Invalid internal port
     InvalidInternalPort {
         loc: Span,
         msg: String,
     },
+    /// Invalid port matching
     InvalidPortMatching {
         loc: Span,
         msg: String,
     },
+    /// Invalid telemetry channel identifier name
     InvalidTlmChannelName {
         loc: Span,
         name: String,
         component_name: String,
     },
+    /// Invalid component instance definition
     InvalidDefComponentInstance {
         name: String,
         loc: Span,
         msg: String,
     },
+    /// Overlapping ID ranges
     OverlappingIdRanges {
         base_id1: i128,
         name1: String,
@@ -227,6 +267,7 @@ pub enum SemanticError {
         name2: String,
         loc2: Span,
     },
+    /// Duplicate instance
     DuplicateInstance {
         name: String,
         loc: Span,
@@ -243,11 +284,13 @@ pub enum SemanticError {
         name: String,
         msg: String,
     },
+    /// Invalid interface instance
     InvalidInterfaceInstance {
         loc: Span,
         instance_name: String,
         top_name: String,
     },
+    /// Invalid connection
     InvalidConnection {
         loc: Span,
         msg: String,
@@ -256,17 +299,20 @@ pub enum SemanticError {
         from_port_def_loc: Option<Span>,
         to_port_def_loc: Option<Span>,
     },
+    /// Invalid port instance identifier
     InvalidPortInstanceId {
         loc: Span,
         port_name: String,
         instance_type: String,
         interface_name: String,
     },
+    /// Invalid port kind
     InvalidPortKind {
         loc: Span,
         msg: String,
         spec_loc: Span,
     },
+    /// Invalid port number
     InvalidPortNumber {
         loc: Span,
         port_number: i128,
@@ -277,6 +323,7 @@ pub enum SemanticError {
     MissingPortMatching {
         loc: Span,
     },
+    /// Incorrect location specifiers
     IncorrectLocationPath {
         /// Location of the file string literal in the location specifier
         loc: Span,
@@ -285,6 +332,7 @@ pub enum SemanticError {
         /// Location of the actual definition (in the translation unit)
         actual_loc: Span,
     },
+    /// Inconsistent location specifiers
     InconsistentLocationPath {
         /// Location of the first specifier's file string literal
         loc: Span,
@@ -295,29 +343,34 @@ pub enum SemanticError {
         /// The path named by the second specifier
         prev_path: String,
     },
+    /// Incorrect dictionary specifier in location specifier
     IncorrectDictionarySpecifier {
         /// Location of the location specifier
         loc: Span,
         /// Location of the actual definition
         def_loc: Span,
     },
+    /// Inconsistent dictionary specifiers in location specifiers
     InconsistentDictionarySpecifier {
         /// Location of the location specifier
         loc: Span,
         /// Location of the previous specifier
         prev_loc: Span,
     },
+    /// Duplicate output port
     DuplicateOutputConnection {
         loc: Span,
         port_num: i128,
         prev_loc: Span,
     },
+    /// Too many output ports
     TooManyOutputPorts {
         loc: Span,
         num_ports: i128,
         array_size: i128,
         instance_loc: Span,
     },
+    /// Mismatched port numbers
     MismatchedPortNumbers {
         p1_loc: Span,
         p1_number: i128,
@@ -325,6 +378,7 @@ pub enum SemanticError {
         p2_number: i128,
         matching_loc: Span,
     },
+    /// Implicit duplicate connection at matched port
     ImplicitDuplicateConnectionAtMatchedPort {
         loc: Span,
         port: String,
@@ -333,20 +387,24 @@ pub enum SemanticError {
         matching_loc: Span,
         prev_loc: Span,
     },
+    /// Matched port numbering could not find a valid port number
     NoPortAvailableForMatchedNumbering {
         loc1: Span,
         loc2: Span,
         matching_loc: Span,
     },
+    /// Missing connection
     MissingConnection {
         loc: Span,
         matching_loc: Span,
     },
+    /// Duplicate matched connection
     DuplicateMatchedConnection {
         loc: Span,
         prev_loc: Span,
         matching_loc: Span,
     },
+    /// Duplicate connection at matched port
     DuplicateConnectionAtMatchedPort {
         loc: Span,
         port: String,
@@ -354,21 +412,26 @@ pub enum SemanticError {
         prev_loc: Span,
         matching_loc: Span,
     },
+    /// Invalid connection pattern
     InvalidPattern {
         loc: Span,
         msg: String,
     },
+    /// A port is missing from a port interface
     PortInterfaceMissingPort {
         loc: Span,
     },
+    /// A port does not match an expected signature
     PortInterfaceInvalidPort {
         loc: Span,
         def_loc: Span,
     },
+    /// Error while checking whether an instance implements an interface
     InterfaceImplements {
         loc: Span,
         inner: Box<SemanticError>,
     },
+    /// Duplicate pattern
     DuplicatePattern {
         kind: String,
         loc: Span,
@@ -418,9 +481,11 @@ pub enum SemanticError {
     },
 }
 
+/// The result of a compilation step
 pub type SemanticResult<T = ()> = Result<T, SemanticError>;
 
 impl SemanticError {
+    /// Print the error
     pub fn emit(self) {
         Into::<Diagnostic>::into(self).emit();
     }

--- a/fpp_analysis/src/lib.rs
+++ b/fpp_analysis/src/lib.rs
@@ -182,12 +182,12 @@ pub fn resolve_includes<Reader: FileReader>(
 
 /// Check the semantics of a list of translation units.
 ///
-/// The passes run in the order below. A few passes present in the reference
-/// compiler are intentionally absent (see docs/analysis-work-to-go.md):
-///   - template resolution and template interface-arg checking: the template
-///     subsystem is not ported.
+/// The passes run in the order below. A few passes are intentionally absent
+/// (see docs/analysis-work-to-go.md):
+///   - template resolution and template interface-arg checking: not
+///     implemented.
 ///   - constant-expr finalization: folded into `CheckExprTypes` /
-///     `EvalConstantExprs` in this design.
+///     `EvalConstantExprs`.
 ///   - dictionary-map construction: codegen-support only, deferred.
 pub fn check_semantics(a: &mut Analysis, ast: Vec<&fpp_ast::TransUnit>) -> ControlFlow<()> {
     EnterSymbols.visit_trans_units(a, ast.iter().cloned())?;

--- a/fpp_analysis/src/passes/check_component_instance_defs.rs
+++ b/fpp_analysis/src/passes/check_component_instance_defs.rs
@@ -18,6 +18,8 @@ impl CheckComponentInstanceDefs {
             let i1 = instances[idx];
             let i2 = instances[idx + 1];
             if i2.max_id >= i2.base_id && i1.base_id >= i2.base_id {
+                // Error: i2 has a nonempty ID range, and
+                // base id for i1 lies in the ID range of i2
                 SemanticError::OverlappingIdRanges {
                     base_id1: i1.base_id,
                     name1: i1.name.clone(),
@@ -30,8 +32,10 @@ impl CheckComponentInstanceDefs {
                 .emit();
                 return;
             } else if i1.max_id < i2.base_id {
+                // OK: ID ranges do not overlap; continue checking
                 idx += 1;
             } else {
+                // Error: Base id for i2 lies in the ID range of i1
                 SemanticError::OverlappingIdRanges {
                     base_id1: i2.base_id,
                     name1: i2.name.clone(),

--- a/fpp_analysis/src/passes/check_expr_types.rs
+++ b/fpp_analysis/src/passes/check_expr_types.rs
@@ -19,6 +19,8 @@ use rustc_hash::FxHashMap as HashMap;
 use std::ops::{ControlFlow, Deref};
 use std::sync::Arc;
 
+/// Compute and check expression types, except for array sizes
+/// and default values
 pub struct CheckExprTypes<'ast> {
     super_: UseAnalyzer<'ast, Self>,
 }
@@ -400,7 +402,7 @@ impl<'ast> Visitor<'ast> for CheckExprTypes<'ast> {
                     .emit(),
                 }
             }
-            ExprKind::Ident(_) => {} // already handled by constantUse
+            ExprKind::Ident(_) => {} // already handled by constant_use
             ExprKind::LiteralBool(_) => {
                 a.type_map.insert(node.node_id, Arc::new(Type::Boolean));
             }
@@ -684,6 +686,7 @@ impl<'ast> UseAnalysisPass<'ast, Analysis> for CheckExprTypes<'ast> {
             // Enum symbol: if this is in scope, then we are in
             // the enum definition, so it already has a type
             Symbol::EnumConstant(_) => {}
+            // Invalid use of a symbol in an expression
             _ => {
                 SemanticError::InvalidSymbol {
                     symbol_name: symbol.name().data.clone(),

--- a/fpp_analysis/src/passes/check_topology_defs.rs
+++ b/fpp_analysis/src/passes/check_topology_defs.rs
@@ -21,6 +21,7 @@ impl CheckTopologyDefs {
     }
 
     fn resolve(&self, a: &mut Analysis, symbol: &Symbol) {
+        // Topology is already resolved: nothing to do.
         if a.topology_map.contains_key(symbol) {
             return;
         }
@@ -35,6 +36,7 @@ impl CheckTopologyDefs {
             self.resolve(a, dep);
         }
 
+        // Visit topology members and compute the unresolved topology.
         let Some(mut top) = a.partial_topology_map.get(symbol).cloned() else {
             return;
         };

--- a/fpp_analysis/src/passes/check_topology_instances.rs
+++ b/fpp_analysis/src/passes/check_topology_instances.rs
@@ -30,6 +30,7 @@ impl<'ast> Visitor<'ast> for CheckTopologyInstances {
         node: &'ast DefTopology,
     ) -> ControlFlow<Self::Break> {
         let symbol = a.get_symbol(node);
+        // Topology is already in the map: nothing to do.
         if a.partial_topology_map.contains_key(&symbol) {
             return ControlFlow::Continue(());
         }
@@ -41,6 +42,7 @@ impl<'ast> Visitor<'ast> for CheckTopologyInstances {
             node.span(),
             node.implements.clone(),
         ));
+        // Visit topology members and compute the unresolved topology.
         let _ = node.walk(a, self);
         if let Some(top) = a.topology.take() {
             a.partial_topology_map.insert(symbol, top);

--- a/fpp_analysis/src/passes/check_type_uses.rs
+++ b/fpp_analysis/src/passes/check_type_uses.rs
@@ -13,6 +13,9 @@ use rustc_hash::FxHashMap as HashMap;
 use std::ops::{ControlFlow, Deref};
 use std::sync::Arc;
 
+/// Compute and check the types of type definition symbols, enumerated
+/// constant symbols, and type names, except that array size expressions and
+/// default value expressions are still unevaluated.
 pub struct CheckTypeUses<'ast> {
     super_: UseAnalyzer<'ast, Self>,
 }

--- a/fpp_analysis/src/passes/check_use_def_cycles.rs
+++ b/fpp_analysis/src/passes/check_use_def_cycles.rs
@@ -8,6 +8,7 @@ use fpp_ast::*;
 use fpp_core::Spanned;
 use std::ops::ControlFlow;
 
+/// Check for use-def cycles
 pub struct CheckUseDefCycles<'ast> {
     super_: UseAnalyzer<'ast, Self>,
 }

--- a/fpp_analysis/src/passes/check_uses.rs
+++ b/fpp_analysis/src/passes/check_uses.rs
@@ -7,6 +7,7 @@ use fpp_ast::{AstNode, Expr, ExprKind, Ident, Node, QualIdent, Visitable, Visito
 use fpp_core::Spanned;
 use std::ops::{ControlFlow, Deref};
 
+/// Match uses to their definitions
 pub struct CheckUses<'ast> {
     super_: BasicUseAnalyzer<'ast, Analysis, Self>,
 }
@@ -59,6 +60,7 @@ impl<'ast> CheckUses<'ast> {
         }
     }
 
+    /// Visit a qualified identifier node and check a use
     fn visit_qual_ident_impl(
         &self,
         a: &mut Analysis,
@@ -106,6 +108,7 @@ impl<'ast> CheckUses<'ast> {
     ) {
         let sym_qualified_name = a.get_qualified_name(sym);
         let iu_name = iu_name.to_string();
+        // Check that the name of the def matches the name of the use
         if sym_qualified_name != iu_name {
             let msg = if sym_qualified_name.len() < iu_name.len() {
                 // Definition has a shorter name: the use is a member of the definition

--- a/fpp_analysis/src/passes/enter_symbols.rs
+++ b/fpp_analysis/src/passes/enter_symbols.rs
@@ -6,6 +6,7 @@ use fpp_core::Spanned;
 use std::ops::ControlFlow;
 use std::sync::Arc;
 
+/// Enter symbols into their scopes
 pub struct EnterSymbols;
 
 impl EnterSymbols {

--- a/fpp_analysis/src/passes/eval_constant_exprs.rs
+++ b/fpp_analysis/src/passes/eval_constant_exprs.rs
@@ -18,6 +18,7 @@ use rustc_hash::FxHashMap as HashMap;
 use std::ops::{ControlFlow, Deref};
 use std::sync::Arc;
 
+/// Compute the values of constant symbols and expressions
 pub struct EvalConstantExprs<'ast> {
     super_: UseAnalyzer<'ast, Self>,
 }
@@ -284,7 +285,7 @@ impl<'ast> Visitor<'ast> for EvalConstantExprs<'ast> {
                     }
                     Some(_) => {
                         // If the entire dot expression was already resolved by
-                        // a constantUse, the value will already be in this map
+                        // a constant_use, the value will already be in this map
                         // No further work is needed
                     }
                 }
@@ -365,10 +366,15 @@ impl<'ast> Visitor<'ast> for EvalConstantExprs<'ast> {
                 // serialized size.
                 FinalizeTypeDefs::new().ty(a, type_name);
                 if let Some(ty) = a.type_map.get(&type_name.node_id).cloned() {
+                    // Get the finalized type. For a type with a definition,
+                    // the finalized type is mapped to the definition in the
+                    // type map; otherwise the type is already the finalized
+                    // type.
                     let finalized = match ty.def_node_id() {
                         Some(def_node) => a.type_map.get(&def_node).cloned().unwrap_or(ty),
                         None => ty,
                     };
+                    // Use the finalized type to compute the size
                     if let Some(size) = finalized.serialized_size(a) {
                         a.value_map
                             .insert(node.node_id, Value::Integer(IntegerValue(size)));

--- a/fpp_analysis/src/passes/eval_implied_enum_consts.rs
+++ b/fpp_analysis/src/passes/eval_implied_enum_consts.rs
@@ -7,6 +7,7 @@ use fpp_ast::{DefEnum, Node, Visitor};
 use fpp_core::Spanned;
 use std::ops::ControlFlow;
 
+/// Evaluate implied enum constants
 pub struct EvalImpliedEnumConsts<'ast> {
     super_: NestedAnalyzer<'ast, Analysis, Self>,
 }

--- a/fpp_analysis/src/passes/finalize_type_defs.rs
+++ b/fpp_analysis/src/passes/finalize_type_defs.rs
@@ -14,6 +14,8 @@ use fpp_core::Spanned;
 use std::ops::{ControlFlow, Deref};
 use std::sync::Arc;
 
+/// Finalize type definitions. Update the types of uses (type names) that
+/// refer to the definitions.
 pub struct FinalizeTypeDefs<'ast> {
     super_: NestedAnalyzer<'ast, Analysis, Self>,
 }
@@ -136,7 +138,9 @@ impl<'ast> Visitor<'ast> for FinalizeTypeDefs<'ast> {
         }
 
         a.visited_symbol_set.insert(symbol);
+        // Finalize the referenced type
         let ty = self.ty(a, &node.type_name);
+        // Update the alias type in the type map
         a.type_map.insert(
             node.node_id,
             Arc::new(Type::AliasType(AliasType {
@@ -159,6 +163,7 @@ impl<'ast> Visitor<'ast> for FinalizeTypeDefs<'ast> {
         }
 
         a.visited_symbol_set.insert(symbol);
+        // Finalize the element type
         let elt_type = self.ty(a, &node.elt_type);
 
         let size = match self.expr_as_integer(a, &node.size) {
@@ -186,6 +191,7 @@ impl<'ast> Visitor<'ast> for FinalizeTypeDefs<'ast> {
             return ControlFlow::Continue(());
         }
 
+        // Update the size and element type
         let anon_array = AnonArrayType {
             size: Some(size as usize),
             elt_type: elt_type.clone(),
@@ -229,6 +235,7 @@ impl<'ast> Visitor<'ast> for FinalizeTypeDefs<'ast> {
             format,
         });
 
+        // Update the array type in the type map
         a.type_map.insert(node.node_id, Arc::new(ty));
         ControlFlow::Continue(())
     }
@@ -286,11 +293,13 @@ impl<'ast> Visitor<'ast> for FinalizeTypeDefs<'ast> {
         };
 
         for member in &node.members {
+            // Finalize the member's type
             let member_ty = self.ty(a, &member.type_name);
             ty.anon_struct
                 .members
                 .insert(member.name.data.clone(), member_ty.clone());
 
+            // Compute the size
             let size = self.expr_as_integer_opt(a, &member.size);
             match size {
                 None => {}
@@ -316,6 +325,7 @@ impl<'ast> Visitor<'ast> for FinalizeTypeDefs<'ast> {
                 }
             }
 
+            // Compute the format
             if let Some(format) = &member.format {
                 ty.formats.insert(
                     member.name.data.clone(),
@@ -324,6 +334,7 @@ impl<'ast> Visitor<'ast> for FinalizeTypeDefs<'ast> {
             }
         }
 
+        // Update the struct type in the type map
         a.type_map.insert(node.node_id, Arc::new(Type::Struct(ty)));
         ControlFlow::Continue(())
     }

--- a/fpp_analysis/src/semantics/component.rs
+++ b/fpp_analysis/src/semantics/component.rs
@@ -72,6 +72,7 @@ impl Command {
         matches!(self.kind, Some(CommandKind::Async { .. }))
     }
 
+    /// Creates a command from a command specifier.
     pub fn from_spec_command(a: &Analysis, node: &SpecCommand) -> SemanticResult<Command> {
         let loc = node.span();
         if !matches!(node.kind, InputPortKind::Async) {
@@ -117,6 +118,7 @@ pub struct TlmChannel {
 }
 
 impl TlmChannel {
+    /// Creates a telemetry channel from a telemetry channel specifier.
     pub fn from_spec(a: &Analysis, node: &SpecTlmChannel) -> SemanticResult<TlmChannel> {
         let loc = node.span();
         let channel_type = a.type_map.get(&node.type_name.node_id).unwrap().clone();
@@ -137,6 +139,7 @@ impl TlmChannel {
     }
 }
 
+/// Computes limits from AST limits.
 fn compute_limits(_a: &Analysis, limits: &[fpp_ast::TlmChannelLimit]) -> SemanticResult {
     let mut seen: HashMap<String, Span> = HashMap::default();
     for limit in limits {
@@ -159,6 +162,7 @@ pub struct Record {
 }
 
 impl Record {
+    /// Creates a record from a record specifier.
     pub fn from_spec(a: &Analysis, node: &SpecRecord) -> SemanticResult<Record> {
         a.check_displayable_type(
             node.record_type.node_id,
@@ -180,6 +184,7 @@ pub struct Container {
 }
 
 impl Container {
+    /// Creates a container from a container specifier.
     pub fn from_spec(a: &Analysis, node: &SpecContainer) -> SemanticResult<Container> {
         a.get_nonnegative_big_int_value_opt(&node.default_priority)?;
         Ok(Container {
@@ -265,6 +270,7 @@ pub struct Event {
 }
 
 impl Event {
+    /// Creates an event from an event specifier.
     pub fn from_spec(a: &Analysis, node: &SpecEvent) -> SemanticResult<Event> {
         let loc = node.span();
         if Analysis::get_num_ref_params(&node.params) != 0 {
@@ -412,23 +418,40 @@ impl StateMachineInstance {
 #[derive(Debug, Clone)]
 pub struct Component {
     pub symbol: Symbol,
+    /// The AST node defining the component.
     pub node: Arc<DefComponent>,
     pub loc: Span,
+    /// The port interface of the component.
     pub port_interface: PortInterface,
+    /// The map from command opcodes to commands.
     pub command_map: HashMap<i128, Command>,
+    /// The next default opcode.
     pub default_opcode: i128,
+    /// The map from telemetry channel IDs to channels.
     pub tlm_channel_map: HashMap<i128, TlmChannel>,
+    /// The map from telemetry channel names to channels.
     pub tlm_channel_name_map: HashMap<String, TlmChannel>,
+    /// The next default channel ID.
     pub default_tlm_channel_id: i128,
+    /// The map from event IDs to events.
     pub event_map: HashMap<i128, Event>,
+    /// The next default event ID.
     pub default_event_id: i128,
+    /// The map from parameter IDs to parameters.
     pub param_map: HashMap<i128, Param>,
+    /// The next default parameter ID.
     pub default_param_id: i128,
+    /// The map from container IDs to containers.
     pub container_map: HashMap<i128, Container>,
+    /// The next default container ID.
     pub default_container_id: i128,
+    /// The map from record IDs to records.
     pub record_map: HashMap<i128, Record>,
+    /// The next default record ID.
     pub default_record_id: i128,
+    /// The map from state machine instance names to state machine instances.
     pub state_machine_instance_map: HashMap<String, StateMachineInstance>,
+    /// The list of port matching specifiers.
     pub spec_port_matching_list: Vec<Arc<SpecPortMatching>>,
     /// The resolved port matchings of this component. Populated with the
     /// matched-port-numbering phase; empty otherwise.
@@ -623,6 +646,9 @@ impl Component {
         )?;
         let mut c = self.clone();
         c.tlm_channel_map = map;
+        // Add the channel to the channel name map. If there is a duplicate
+        // name, we will catch it later when we check all the dictionary
+        // elements.
         c.tlm_channel_name_map.insert(name, channel);
         c.default_tlm_channel_id = next;
         Ok(c)
@@ -630,6 +656,7 @@ impl Component {
 
     /// Add a parameter
     pub fn add_param(&self, id_opt: Option<i128>, param: Param) -> SemanticResult<Component> {
+        // Update the parameter map and the default parameter ID.
         let (map, next) = add_element_to_id_map(
             &self.param_map,
             id_opt.unwrap_or(self.default_param_id),
@@ -639,6 +666,7 @@ impl Component {
         let mut c = self.clone();
         c.param_map = map;
         c.default_param_id = next;
+        // Add the implicit set and save commands.
         let upper = param.name.to_uppercase();
         let set_command = Command {
             loc: param.loc,
@@ -928,6 +956,7 @@ fn add_element_to_id_map<T: Clone>(
     Ok((m, id + 1))
 }
 
+/// Checks for duplicate names in dictionary.
 fn check_dictionary_names<T>(
     map: &HashMap<i128, T>,
     kind: &str,

--- a/fpp_analysis/src/semantics/connection.rs
+++ b/fpp_analysis/src/semantics/connection.rs
@@ -139,7 +139,9 @@ impl Ord for InterfaceInstance {
 /// A resolved FPP port instance identifier.
 #[derive(Debug, Clone)]
 pub struct PortInstanceIdentifier {
+    /// The interface instance.
     pub interface_instance: InterfaceInstance,
+    /// The port instance.
     pub port_instance: PortInstance,
 }
 
@@ -155,6 +157,7 @@ impl PartialOrd for PortInstanceIdentifier {
     }
 }
 impl Ord for PortInstanceIdentifier {
+    /// Compare two port instance identifiers.
     fn cmp(&self, other: &Self) -> Ordering {
         self.qualified_name().cmp(&other.qualified_name())
     }
@@ -265,11 +268,13 @@ impl Endpoint {
     /// component-instance port.
     pub fn get_underlying_endpoint(&self, a: &Analysis) -> Endpoint {
         match &self.port.interface_instance {
+            // This endpoint is already a component instance
             InterfaceInstance::Component(_) => self.clone(),
             InterfaceInstance::Topology(_) => {
                 let Some(top) = self.port.interface_instance.as_topology(a) else {
                     return self.clone();
                 };
+                // Look up the mapping for this port instance
                 let name = self.port.port_instance.get_unqualified_name();
                 match top.port_map.get(name) {
                     Some(tp) => {
@@ -279,6 +284,7 @@ impl Endpoint {
                             port_number: self.port_number,
                             topology_port: Some(Box::new(self.clone())),
                         };
+                        // Recursively resolve the endpoint to a component instance
                         next.get_underlying_endpoint(a)
                     }
                     None => self.clone(),
@@ -308,7 +314,9 @@ impl Endpoint {
 /// A resolved FPP connection.
 #[derive(Debug, Clone)]
 pub struct Connection {
+    /// The from endpoint.
     pub from: Endpoint,
+    /// The to endpoint.
     pub to: Endpoint,
     pub is_unmatched: bool,
 }
@@ -325,6 +333,7 @@ impl PartialOrd for Connection {
     }
 }
 impl Ord for Connection {
+    /// Compare two connections.
     fn cmp(&self, other: &Self) -> Ordering {
         self.from
             .cmp(&other.from)

--- a/fpp_analysis/src/semantics/format.rs
+++ b/fpp_analysis/src/semantics/format.rs
@@ -42,6 +42,7 @@ pub enum FormatPart {
     FormatReplacement(FormatReplacementField),
 }
 
+/// An FPP presentation format
 #[derive(Debug, Clone)]
 pub struct Format(pub Vec<FormatPart>);
 
@@ -80,6 +81,7 @@ impl Format {
                     FormatReplacementKind::Rational { kind, precision } => {
                         match *precision {
                             None => {}
+                            // The maximum allowed precision is 100
                             Some(precision) if precision > 100 => {
                                 SemanticError::FormatStringInvalidPrecision {
                                     loc: format_spec.span,
@@ -142,6 +144,7 @@ impl Format {
     }
 }
 
+/// Parses a format string into a format
 struct FormatParser<'a> {
     parent_span: fpp_core::Span,
     pos: BytePos,

--- a/fpp_analysis/src/semantics/format_spec.rs
+++ b/fpp_analysis/src/semantics/format_spec.rs
@@ -8,7 +8,7 @@ use fpp_core::{CompilerContext, DiagnosticData, DiagnosticEmitter, Level, Node, 
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
-// Comparable, span-free shape mirroring the Scala `Format` structure.
+// Comparable, span-free shape for Format's parsed representation.
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, PartialEq, Clone)]
@@ -58,9 +58,9 @@ fn shape(p: &FormatPart) -> Shape {
 }
 
 // ---------------------------------------------------------------------------
-// Error-counting emitter: mirrors the `WriteEmitter`-buffer pattern used in
-// `types.rs`, but keeps a precise count of error-level diagnostics so we don't
-// have to string-match rendered output.
+// Error-counting emitter: follows the same `WriteEmitter`-buffer pattern used
+// in `types.rs`, but keeps a precise count of error-level diagnostics so we
+// don't have to string-match rendered output.
 // ---------------------------------------------------------------------------
 
 #[derive(Default)]
@@ -85,7 +85,7 @@ struct ParseResult {
     /// With an empty type list, the only non-parser error `Format::new` can
     /// raise is the length-mismatch (one field vs. zero types). We subtract
     /// those out here so `parser_errors` reflects *only* the format parser's
-    /// own diagnostics (Scala's `NoSuccess`).
+    /// own diagnostics.
     parser_errors: usize,
 }
 
@@ -128,14 +128,13 @@ fn parse(input: &str) -> ParseResult {
 }
 
 // ---------------------------------------------------------------------------
-// "format" should parse <input> as <expected>   (Scala `ok` list)
+// "format" should parse <input> as <expected>
 // ---------------------------------------------------------------------------
 
 #[test]
 fn parses_ok_cases() {
-    // (input, expected span-free shape). Mirrors the Scala `ok` list exactly.
-    // Scala's `Format(prefix, List((field, suffix)))` flattens to a `Vec` of
-    // interleaved literals and replacement fields.
+    // (input, expected span-free shape) pairs. The parsed representation
+    // flattens to a `Vec` of interleaved literals and replacement fields.
     let ok: Vec<(&str, Vec<Shape>)> = vec![
         ("abcd", vec![Shape::Literal("abcd".into())]),
         ("ab{{cd", vec![Shape::Literal("ab{cd".into())]),
@@ -237,13 +236,13 @@ fn parses_ok_cases() {
 }
 
 // ---------------------------------------------------------------------------
-// "format" should not parse <input>   (Scala `error` list)
+// "format" should not parse <input>
 // ---------------------------------------------------------------------------
 
 #[test]
 fn rejects_error_cases() {
-    // Scala checks these produce `NoSuccess`. Rust surfaces the failure by
-    // emitting one or more error-level diagnostics from the format parser.
+    // These inputs fail to parse; the failure surfaces as one or more
+    // error-level diagnostics emitted by the format parser.
     let error_inputs = ["{", "}", "ab{1234xyz}cd", "ab{.3b}cd"];
 
     for input in error_inputs {

--- a/fpp_analysis/src/semantics/generic_name_symbol_map.rs
+++ b/fpp_analysis/src/semantics/generic_name_symbol_map.rs
@@ -3,6 +3,7 @@ use crate::semantics::SymbolInterface;
 use fpp_core::Spanned;
 use rustc_hash::FxHashMap as HashMap;
 
+/// A type-generic local mapping of unqualified names to symbols
 #[derive(Debug, Clone)]
 pub struct GenericNameSymbolMap<S: SymbolInterface>(HashMap<String, S>);
 
@@ -11,11 +12,12 @@ impl<S: SymbolInterface> GenericNameSymbolMap<S> {
         Self(HashMap::default())
     }
 
-    /** Get a symbol from the map. Return none if the name is not there. */
+    /// Get a symbol from the map. Return none if the name is not there.
     pub fn get(&self, name: &str) -> Option<S> {
         self.0.get(name).cloned()
     }
 
+    /// Put a name and symbol into the map.
     pub fn put(&mut self, symbol: S) -> SemanticResult {
         let name = symbol.name().data.as_str();
         match self.0.get(name) {

--- a/fpp_analysis/src/semantics/generic_nested_scope.rs
+++ b/fpp_analysis/src/semantics/generic_nested_scope.rs
@@ -3,6 +3,8 @@ use crate::semantics::generic_name_symbol_map::GenericNameSymbolMap;
 use fpp_util::EnumMap;
 use std::marker::PhantomData;
 
+/// A stack of scopes, from outermost to innermost. Each level is identified by the
+/// symbol whose scope is open there, with `None` marking the outermost (global) scope.
 #[derive(Debug, Clone)]
 pub struct GenericNestedScope<NG: Copy, S: SymbolInterface, M: EnumMap<NG, GenericNameSymbolMap<S>>>(
     Vec<Option<S>>,
@@ -13,6 +15,7 @@ pub struct GenericNestedScope<NG: Copy, S: SymbolInterface, M: EnumMap<NG, Gener
 impl<NG: Copy, S: SymbolInterface, M: EnumMap<NG, GenericNameSymbolMap<S>>>
     GenericNestedScope<NG, S, M>
 {
+    /// Create an empty nested scope, containing only the outermost scope
     pub fn new() -> Self {
         Self(vec![None], Default::default(), Default::default())
     }
@@ -22,6 +25,7 @@ impl<NG: Copy, S: SymbolInterface, M: EnumMap<NG, GenericNameSymbolMap<S>>>
         self.0.push(Some(symbol));
     }
 
+    /// Pop a scope off the stack
     pub fn pop(&mut self) {
         self.0.pop();
     }
@@ -32,6 +36,7 @@ impl<NG: Copy, S: SymbolInterface, M: EnumMap<NG, GenericNameSymbolMap<S>>>
         self.0.iter().rev().find_map(predicate)
     }
 
+    /// Get the innermost scope
     pub fn current(&self) -> &Option<S> {
         self.0.last().unwrap()
     }

--- a/fpp_analysis/src/semantics/generic_scope.rs
+++ b/fpp_analysis/src/semantics/generic_scope.rs
@@ -4,6 +4,7 @@ use crate::semantics::generic_name_symbol_map::GenericNameSymbolMap;
 use fpp_util::EnumMap;
 use std::marker::PhantomData;
 
+/// A generic collection of name-symbol maps, one for each name group
 #[derive(Debug, Clone, Copy)]
 pub struct GenericScope<NG, S: SymbolInterface, M: EnumMap<NG, GenericNameSymbolMap<S>>>(
     M,
@@ -31,6 +32,7 @@ impl<NG, S: SymbolInterface, M: EnumMap<NG, GenericNameSymbolMap<S>>> GenericSco
         self.0.get_mut(name_group).put(symbol)
     }
 
+    /// Get the name-symbol map for a name group
     pub fn get_group(&self, name_group: NG) -> &GenericNameSymbolMap<S> {
         self.0.get(name_group)
     }

--- a/fpp_analysis/src/semantics/implied_use.rs
+++ b/fpp_analysis/src/semantics/implied_use.rs
@@ -1,7 +1,7 @@
 use crate::semantics::QualifiedName;
 use fpp_core::Spanned;
 
-/** The kind of an implied use */
+/// The kind of an implied use
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum ImpliedUseKind {
     Constant,
@@ -9,7 +9,7 @@ pub enum ImpliedUseKind {
     Type,
 }
 
-/** The set of implied uses associated with a single AST node, grouped by kind */
+/// The set of implied uses associated with a single AST node, grouped by kind
 #[derive(Clone, Default, Debug)]
 pub struct ImpliedUseSet {
     pub constants: Vec<ImpliedUse>,
@@ -17,11 +17,12 @@ pub struct ImpliedUseSet {
     pub types: Vec<ImpliedUse>,
 }
 
+/// An implied use of an FPP symbol
 #[derive(Clone, Debug)]
 pub struct ImpliedUse {
-    /** The fully-qualified name of the implied use */
+    /// The fully-qualified name of the implied use
     name: QualifiedName,
-    /** The AST node id associated with the implied use */
+    /// The AST node id associated with the implied use
     id: fpp_core::Node,
 }
 
@@ -30,8 +31,8 @@ impl ImpliedUse {
         ImpliedUse { name, id }
     }
 
-    /** Construct an implied use from an identifier list, replicating the node id
-     * so the implied use has its own stable, distinct node id */
+    /// Construct an implied use from an identifier list, replicating the node id
+    /// so the implied use has its own stable, distinct node id
     pub fn from_ident_list_and_id(idents: Vec<String>, id: fpp_core::Node) -> ImpliedUse {
         ImpliedUse {
             name: idents.into(),
@@ -47,6 +48,7 @@ impl ImpliedUse {
         &self.name
     }
 
+    /// Create a new ID at the same location as id
     fn replicate_node_id(id: fpp_core::Node) -> fpp_core::Node {
         fpp_core::Node::new(id.span())
     }

--- a/fpp_analysis/src/semantics/interface.rs
+++ b/fpp_analysis/src/semantics/interface.rs
@@ -16,6 +16,7 @@ pub enum Direction {
 }
 
 impl Direction {
+    /// Show a direction option.
     pub fn show(dir: &Option<Direction>) -> &'static str {
         match dir {
             Some(Direction::Input) => "input",
@@ -86,6 +87,7 @@ pub enum GeneralKind {
 /// An FPP port instance.
 #[derive(Debug, Clone)]
 pub enum PortInstance {
+    /// A general port instance.
     General {
         node_id: Node,
         loc: Span,
@@ -95,6 +97,7 @@ pub enum PortInstance {
         ty: PortInstanceType,
         import_locs: Vec<Span>,
     },
+    /// A special port instance.
     Special {
         node_id: Node,
         loc: Span,
@@ -124,6 +127,7 @@ pub enum PortInstance {
 }
 
 impl PortInstance {
+    /// Gets the unqualified name of the port instance.
     pub fn get_unqualified_name(&self) -> &str {
         match self {
             PortInstance::General { name, .. }
@@ -133,6 +137,7 @@ impl PortInstance {
         }
     }
 
+    /// Gets the location of the port instance.
     pub fn get_loc(&self) -> Span {
         match self {
             PortInstance::General { loc, .. }
@@ -142,6 +147,7 @@ impl PortInstance {
         }
     }
 
+    /// Gets the node ID of the port instance.
     pub fn get_node_id(&self) -> Node {
         match self {
             PortInstance::General { node_id, .. }
@@ -151,6 +157,7 @@ impl PortInstance {
         }
     }
 
+    /// Gets the size of the port array.
     pub fn get_array_size(&self) -> i128 {
         match self {
             PortInstance::General { size, .. } => *size,
@@ -159,6 +166,7 @@ impl PortInstance {
         }
     }
 
+    /// Gets the direction of the port instance.
     pub fn get_direction(&self) -> Option<Direction> {
         match self {
             PortInstance::General { kind, .. } => Some(match kind {
@@ -176,6 +184,7 @@ impl PortInstance {
         }
     }
 
+    /// Gets the type of the port instance.
     pub fn get_type(&self) -> Option<PortInstanceType> {
         match self {
             PortInstance::General { ty, .. } => Some(ty.clone()),
@@ -185,6 +194,7 @@ impl PortInstance {
         }
     }
 
+    /// Gets the special kind of the port instance, if any.
     pub fn get_special_kind(&self) -> Option<SpecialPortInstanceKind> {
         match self {
             PortInstance::Special { kind, .. } => Some(kind.clone()),
@@ -238,6 +248,10 @@ impl PortInstance {
         }
     }
 
+    /// Gets the locations of the import specifiers (if this port was imported).
+    /// The first item is the import of the parent interface. The final item is
+    /// the import into the component. All the in-between locs are for imports
+    /// into other interfaces.
     pub fn get_import_locs(&self) -> &[Span] {
         match self {
             PortInstance::General { import_locs, .. }
@@ -253,6 +267,7 @@ impl PortInstance {
             PortInstance::General { import_locs, .. }
             | PortInstance::Special { import_locs, .. }
             | PortInstance::Internal { import_locs, .. } => import_locs.push(import_loc),
+            // Topology ports cannot be imported.
             PortInstance::Topology { .. } => {}
         }
         clone
@@ -278,19 +293,24 @@ impl PortInstance {
             specifier.kind,
             GeneralPortInstanceKind::Input(InputPortKind::Async)
         ) {
+            // Check the priority specifier
             if let Some(priority) = &specifier.priority {
                 return Err(SemanticError::InvalidPriority {
                     loc: priority.span(),
                 });
             }
+            // Check the queue full specifier
             if specifier.queue_full.is_some() {
                 return Err(SemanticError::InvalidQueueFull { loc });
             }
         }
 
+        // Get the size
         let size = a.get_array_size_opt(&specifier.size)?;
+        // Get the priority
         let priority = a.get_big_int_value_opt(&specifier.priority);
 
+        // Get the type
         let ty = match &specifier.port {
             Some(qid) => match a.use_def_map.get(&qid.id()) {
                 Some(symbol @ Symbol::Port(_)) => PortInstanceType::DefPort(symbol.clone()),
@@ -349,6 +369,7 @@ impl PortInstance {
         };
 
         let kind_string = specifier.kind.to_string();
+        // Check the input kind
         match (&specifier.input_kind, &specifier.kind) {
             (Some(_), SpecialPortInstanceKind::ProductRecv) => {}
             (Some(_), _) => {
@@ -367,16 +388,19 @@ impl PortInstance {
         }
 
         if !matches!(specifier.input_kind, Some(InputPortKind::Async)) {
+            // Check the priority specifier
             if let Some(priority) = &specifier.priority {
                 return Err(SemanticError::InvalidPriority {
                     loc: priority.span(),
                 });
             }
+            // Check the queue full specifier
             if specifier.queue_full.is_some() {
                 return Err(SemanticError::InvalidQueueFull { loc });
             }
         }
 
+        // Get the priority
         let priority = a.get_big_int_value_opt(&specifier.priority);
         let queue_full = match specifier.kind {
             SpecialPortInstanceKind::ProductRecv => {
@@ -423,6 +447,7 @@ impl PortInstance {
     }
 }
 
+/// Checks general async input port specifiers.
 fn check_general_async_input(instance: &PortInstance) -> SemanticResult {
     if let PortInstance::General {
         loc,
@@ -444,8 +469,11 @@ fn check_general_async_input(instance: &PortInstance) -> SemanticResult {
 /// A set of port instances (shared by interfaces and components).
 #[derive(Debug, Clone)]
 pub struct PortInterface {
+    /// The type of interface instance this port interface represents.
     pub instance_type: String,
+    /// The map from port names to port instances.
     pub port_map: HashMap<String, PortInstance>,
+    /// The map from special port kinds to special port instances.
     pub special_port_map: HashMap<String, PortInstance>,
 }
 
@@ -527,9 +555,11 @@ impl PortInterface {
     /// Check that `self` implements `other`: every port (general and special)
     /// in `other` exists in `self` with a matching signature.
     pub fn implements(&self, other: &PortInterface) -> SemanticResult {
+        // Check all the ports in `other` to make sure they exist and match `self`
         for (name, pi) in &other.port_map {
             match self.port_map.get(name) {
                 Some(found) => {
+                    // Port exists, make sure it matches theirs
                     if !found.signature_eq(pi) {
                         return Err(SemanticError::PortInterfaceInvalidPort {
                             loc: found.get_loc(),
@@ -545,6 +575,7 @@ impl PortInterface {
         for (kind, pi) in &other.special_port_map {
             match self.special_port_map.get(kind) {
                 Some(found) => {
+                    // The port exists, make sure it's the same as theirs
                     if !found.signature_eq(pi) {
                         return Err(SemanticError::PortInterfaceInvalidPort {
                             loc: found.get_loc(),
@@ -587,9 +618,11 @@ impl PortInterface {
 /// An FPP interface.
 #[derive(Debug, Clone)]
 pub struct Interface {
+    /// The symbol defining the interface.
     pub symbol: Symbol,
     /// Imported interfaces: symbol -> (import node, import location).
     pub import_map: HashMap<Symbol, (Node, Span)>,
+    /// The port interface of the component.
     pub port_interface: PortInterface,
 }
 
@@ -602,6 +635,7 @@ impl Interface {
         }
     }
 
+    /// Add a port instance.
     pub fn add_port_instance(&self, instance: PortInstance) -> SemanticResult<Interface> {
         let pi = self.port_interface.add_port_instance(instance)?;
         let mut result = self.clone();

--- a/fpp_analysis/src/semantics/name.rs
+++ b/fpp_analysis/src/semantics/name.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt::{Debug, Display, Formatter, Write};
 
+/// A qualified or unqualified name
 #[derive(Clone)]
 pub struct QualifiedName {
     qualifier: VecDeque<String>,
@@ -8,6 +9,7 @@ pub struct QualifiedName {
 }
 
 impl QualifiedName {
+    /// Convert a qualified name to an identifier list
     pub fn to_ident_list(&self) -> VecDeque<String> {
         let mut out = self.qualifier.clone();
         out.push_back(self.base.clone());
@@ -15,6 +17,7 @@ impl QualifiedName {
     }
 }
 
+/// Create a qualified name from an identifier
 impl From<String> for QualifiedName {
     fn from(value: String) -> Self {
         QualifiedName {
@@ -31,6 +34,7 @@ impl From<Vec<String>> for QualifiedName {
     }
 }
 
+/// Create a qualified name A.B.C from an identifier list [ A, B, C ]
 impl From<VecDeque<String>> for QualifiedName {
     fn from(mut value: VecDeque<String>) -> Self {
         let base = value
@@ -43,6 +47,7 @@ impl From<VecDeque<String>> for QualifiedName {
     }
 }
 
+/// Create a qualified name from a qualified identifier
 impl From<&fpp_ast::QualIdent> for QualifiedName {
     fn from(value: &fpp_ast::QualIdent) -> Self {
         fn to_qualifier(value: &fpp_ast::QualIdent, mut q: VecDeque<String>) -> VecDeque<String> {
@@ -84,6 +89,7 @@ impl Debug for QualifiedName {
     }
 }
 
+/// Convert a qualified name to a string
 impl Display for QualifiedName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let v: Vec<String> = self.to_ident_list().into();

--- a/fpp_analysis/src/semantics/name_groups.rs
+++ b/fpp_analysis/src/semantics/name_groups.rs
@@ -1,6 +1,7 @@
 use fpp_macros::EnumMap;
 use std::fmt::{Display, Formatter};
 
+/// A name group
 #[derive(EnumMap, Copy, Clone, Debug)]
 pub enum NameGroup {
     Component,

--- a/fpp_analysis/src/semantics/resolve_topology/pattern_resolver.rs
+++ b/fpp_analysis/src/semantics/resolve_topology/pattern_resolver.rs
@@ -1,3 +1,5 @@
+// Resolve connection patterns
+
 use crate::Analysis;
 use crate::errors::{SemanticError, SemanticResult};
 use crate::semantics::{
@@ -79,6 +81,7 @@ fn resolve_to_single_port(
     }
 }
 
+/// Gets the specified general port from a component instance
 fn get_general_port(
     a: &Analysis,
     ci_use: &(ComponentInstance, Span),
@@ -210,6 +213,7 @@ fn for_targets(
     Ok(result)
 }
 
+/// Resolve a command pattern
 fn resolve_command(
     a: &Analysis,
     pattern: &ConnectionPattern,
@@ -256,6 +260,7 @@ fn resolve_command(
     })
 }
 
+/// Resolve a pattern involving connections from a single special target port
 fn resolve_from_special(
     a: &Analysis,
     pattern: &ConnectionPattern,
@@ -290,6 +295,7 @@ fn get_ping_ports(
     Ok((ping_in, ping_out))
 }
 
+/// Resolve a health pattern
 fn resolve_health(
     a: &Analysis,
     pattern: &ConnectionPattern,
@@ -299,6 +305,7 @@ fn resolve_health(
     let (source_in, source_out) = get_ping_ports(a, &pattern.source)?;
     for_targets(pattern, instances, |target| {
         let (target_in, target_out) = get_ping_ports(a, target)?;
+        // Health component does not ping itself
         if source_out.interface_instance != target_in.interface_instance {
             Ok(vec![
                 (
@@ -316,6 +323,7 @@ fn resolve_health(
     })
 }
 
+/// Resolve a param pattern
 fn resolve_param(
     a: &Analysis,
     pattern: &ConnectionPattern,

--- a/fpp_analysis/src/semantics/scope.rs
+++ b/fpp_analysis/src/semantics/scope.rs
@@ -3,7 +3,9 @@ use crate::semantics::generic_nested_scope::GenericNestedScope;
 use crate::semantics::generic_scope::GenericScope;
 use crate::semantics::{NameGroup, NameGroupMap, Symbol};
 
+/// A stack of scopes
 pub type NestedScope =
     GenericNestedScope<NameGroup, Symbol, NameGroupMap<GenericNameSymbolMap<Symbol>>>;
 
+/// A collection of name-symbol maps, one for each name group
 pub type Scope = GenericScope<NameGroup, Symbol, NameGroupMap<GenericNameSymbolMap<Symbol>>>;

--- a/fpp_analysis/src/semantics/state_machine/type_option.rs
+++ b/fpp_analysis/src/semantics/state_machine/type_option.rs
@@ -107,18 +107,23 @@ impl TypeOption {
     }
 }
 
+/// Tests for the type-option rules used to type state-machine signals,
+/// actions, and guards. These follow the FPP spec section "Type Options"
+/// (docs/spec/Type-Options.adoc): "Conversion of Type Options" and
+/// "Computing a Common Type Option".
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::semantics::test_helpers::*;
     use fpp_ast::IntegerKind;
 
+    // Convenience: wrap a type as Some(t)
     fn some(t: Arc<Type>) -> TypeOptionT {
         Some(t)
     }
 
     /// Structural equality on type options: `None`/`None` and `Some`/`Some`
-    /// with structurally-equal types (mirrors Scala `==` on `Option[Type]`).
+    /// with structurally-equal types.
     fn option_eq(a: &TypeOptionT, b: &TypeOptionT) -> bool {
         match (a, b) {
             (None, None) => true,

--- a/fpp_analysis/src/semantics/symbol.rs
+++ b/fpp_analysis/src/semantics/symbol.rs
@@ -1,8 +1,11 @@
 use fpp_core::Node;
 use std::sync::Arc;
 
+/// The interface for an FPP symbol
 pub trait SymbolInterface: Clone {
+    /// Gets the AST node ID of the symbol
     fn node(&self) -> Node;
+    /// Gets the unqualified name of the symbol
     fn name(&self) -> &fpp_ast::Name;
 }
 
@@ -21,6 +24,7 @@ impl From<&fpp_ast::DefModule> for DefModuleStub {
     }
 }
 
+/// A data structure that represents a definition
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Symbol {
     AbsType(Arc<fpp_ast::DefAbsType>),

--- a/fpp_analysis/src/semantics/test_helpers.rs
+++ b/fpp_analysis/src/semantics/test_helpers.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 thread_local! {
     /// Memoizes `id -> Node` so that repeated builder calls with the same integer
-    /// id return the same node, reproducing Scala's `AstNode.Id` identity model.
+    /// id return the same node, giving each id a stable node identity.
     static NODE_BY_ID: RefCell<HashMap<u64, fpp_core::Node>> = RefCell::new(HashMap::default());
     /// A single shared source file / span for all synthesized nodes.
     static TEST_SPAN: RefCell<Option<fpp_core::Span>> = const { RefCell::new(None) };
@@ -43,7 +43,7 @@ fn test_span() -> fpp_core::Span {
 }
 
 /// Returns the memoized node for `id`, creating it on first use. Same `id`
-/// always yields the same [`fpp_core::Node`] (mirrors Scala `AstNode.Id`).
+/// always yields the same [`fpp_core::Node`].
 fn node_for(id: u64) -> fpp_core::Node {
     NODE_BY_ID.with(|m| {
         *m.borrow_mut()
@@ -61,7 +61,7 @@ fn name_with_id(data: &str, id: u64) -> Name {
 }
 
 // ---------------------------------------------------------------------------
-// Primitive type constants (mirror Scala `Type.{I8..U64,F32,F64,Boolean,Integer}`)
+// Primitive type constants
 // ---------------------------------------------------------------------------
 
 pub fn i8() -> Arc<Type> {
@@ -112,17 +112,16 @@ fn expr_lit_int(value: &str, id: u64) -> Expr {
     }
 }
 
-/// A `string size <size>` type, mirroring Scala `stringWithSize`. The size is
-/// carried as a resolved `i128` (matching Rust's `Type::String(Option<i128>)`).
+/// A `string size <size>` type. The size is carried as a resolved `i128`
+/// (matching Rust's `Type::String(Option<i128>)`).
 pub fn string_with_size(size: i128) -> Arc<Type> {
     Arc::new(Type::String(Some(size)))
 }
 
 // ---------------------------------------------------------------------------
-// Named-type builders (mirror Scala `Types.{absType,aliasType,array,enumeration,struct}`)
+// Named-type builders
 // ---------------------------------------------------------------------------
 
-/// Mirrors Scala `absType(name, id)`.
 pub fn abs_type(name: &str, id: u64) -> Arc<Type> {
     let node = DefAbsType {
         name: name_with_id(name, id),
@@ -134,7 +133,7 @@ pub fn abs_type(name: &str, id: u64) -> Arc<Type> {
     }))
 }
 
-/// A dummy `TypeName` (Scala uses `TypeNameInt(U32)` as a placeholder).
+/// A dummy `TypeName` (`Integer(U32)`) used as a placeholder.
 fn dummy_type_name(id: u64) -> TypeName {
     TypeName {
         kind: TypeNameKind::Integer(IntegerKind::U32),
@@ -142,7 +141,6 @@ fn dummy_type_name(id: u64) -> TypeName {
     }
 }
 
-/// Mirrors Scala `aliasType(name, ty, id)`.
 pub fn alias_type(name: &str, ty: Arc<Type>, id: u64) -> Arc<Type> {
     let node = DefAliasType {
         name: name_with_id(name, id),
@@ -156,7 +154,6 @@ pub fn alias_type(name: &str, ty: Arc<Type>, id: u64) -> Arc<Type> {
     }))
 }
 
-/// Mirrors Scala `array(name, anonArray, id)`.
 pub fn array(name: &str, anon_array: Arc<Type>, id: u64) -> Arc<Type> {
     let anon = match anon_array.deref() {
         Type::AnonArray(a) => a.clone(),
@@ -181,7 +178,6 @@ pub fn array(name: &str, anon_array: Arc<Type>, id: u64) -> Arc<Type> {
     }))
 }
 
-/// Mirrors Scala `enumeration(name, repType, id)`.
 pub fn enumeration(name: &str, rep_type: IntegerKind, id: u64) -> Arc<Type> {
     let node = DefEnum {
         name: name_with_id(name, id),
@@ -202,7 +198,7 @@ pub fn struct_ty(name: &str, anon_struct: Arc<Type>, id: u64) -> Arc<Type> {
     struct_ty_sized(name, anon_struct, id, &[])
 }
 
-/// `struct` with explicit member array sizes (Scala `struct(..., sizes)`).
+/// `struct` with explicit member array sizes.
 pub fn struct_ty_sized(
     name: &str,
     anon_struct: Arc<Type>,
@@ -233,12 +229,10 @@ pub fn struct_ty_sized(
     }))
 }
 
-/// Mirrors Scala `AnonArray(size, eltType)`.
 pub fn anon_array(size: Option<usize>, elt_type: Arc<Type>) -> Arc<Type> {
     Arc::new(Type::AnonArray(AnonArrayType { size, elt_type }))
 }
 
-/// Mirrors Scala `AnonStruct(Map(...))`.
 pub fn anon_struct(members: &[(&str, Arc<Type>)]) -> Arc<Type> {
     let mut m = HashMap::default();
     for (name, ty) in members {
@@ -248,7 +242,7 @@ pub fn anon_struct(members: &[(&str, Arc<Type>)]) -> Arc<Type> {
 }
 
 // ---------------------------------------------------------------------------
-// Default named types (mirror Scala `Types.default*`)
+// Default named types
 // ---------------------------------------------------------------------------
 
 pub fn default_abs_type() -> Arc<Type> {
@@ -271,18 +265,15 @@ pub fn default_alias_type() -> Arc<Type> {
 // Structural type equality (for asserting common-type / conversion results)
 // ---------------------------------------------------------------------------
 
-/// Structural equality on `Type`, matching how the Scala tests compare types
-/// with `==` (case-class structural equality). Named types compare by
-/// definition node id (like Scala's `Type` case classes, whose `AstNode`s carry
-/// stable ids); anonymous aggregates compare structurally on members/elements.
+/// Structural equality on `Type`. Named types compare by definition node id;
+/// anonymous aggregates compare structurally on members/elements.
 pub fn types_structurally_eq(a: &Type, b: &Type) -> bool {
     match (a, b) {
         (Type::PrimitiveInt(k1), Type::PrimitiveInt(k2)) => k1 == k2,
         (Type::Float(k1), Type::Float(k2)) => k1 == k2,
         (Type::Boolean, Type::Boolean) => true,
         (Type::Integer, Type::Integer) => true,
-        // String equality in Scala compares the size AST node; our sizes are
-        // resolved i128 options, so compare those directly.
+        // Sizes are resolved i128 options, so compare those directly.
         (Type::String(s1), Type::String(s2)) => s1 == s2,
         (Type::AnonArray(a1), Type::AnonArray(a2)) => {
             a1.size == a2.size && types_structurally_eq(&a1.elt_type, &a2.elt_type)
@@ -319,7 +310,7 @@ pub fn assert_common_type_eq(actual: &Option<Arc<Type>>, expected: &Arc<Type>) {
 }
 
 // ---------------------------------------------------------------------------
-// Value builders (mirror Scala `Values`)
+// Value builders
 // ---------------------------------------------------------------------------
 
 pub fn v_i8(v: i128) -> Value {
@@ -374,7 +365,7 @@ pub fn v_string(s: &str) -> Value {
     Value::String(StringValue(s.to_string()))
 }
 
-/// An enum constant value over `default_enum()` (Scala `Values.enumeration`).
+/// An enum constant value over `default_enum()`.
 pub fn v_enum_constant(member: &str, value: i128) -> Value {
     Value::EnumConstant(EnumConstantValue::new(
         member.to_string(),
@@ -383,7 +374,7 @@ pub fn v_enum_constant(member: &str, value: i128) -> Value {
     ))
 }
 
-/// An anonymous array value of `size` copies of `v` (Scala `createAnonArray`).
+/// An anonymous array value of `size` copies of `v`.
 pub fn v_anon_array(size: usize, v: Value) -> Value {
     Value::AnonArray(AnonArrayValue {
         elements: std::iter::repeat_n(v, size).collect(),
@@ -391,7 +382,7 @@ pub fn v_anon_array(size: usize, v: Value) -> Value {
 }
 
 // ---------------------------------------------------------------------------
-// SerializedSize test analysis (mirrors the `Analysis(...)` in `TypeSpec` "size of")
+// SerializedSize test analysis
 // ---------------------------------------------------------------------------
 
 /// Builds an [`crate::Analysis`] populated with the framework definitions that
@@ -399,9 +390,8 @@ pub fn v_anon_array(size: usize, v: Value) -> Value {
 /// prefix type, 2 bytes) and `FW_FIXED_LENGTH_STRING_SIZE = 256` (the default
 /// string data size).
 ///
-/// Note: unlike the Scala test, Rust stores string sizes pre-resolved as
-/// `i128`, so no per-string `value_map` entries are needed — only the two
-/// framework definitions.
+/// Note: string sizes are pre-resolved as `i128`, so no per-string
+/// `value_map` entries are needed — only the two framework definitions.
 pub fn sizeof_test_analysis() -> crate::Analysis {
     use crate::semantics::Symbol;
     use fpp_ast::DefConstant;

--- a/fpp_analysis/src/semantics/topology.rs
+++ b/fpp_analysis/src/semantics/topology.rs
@@ -35,7 +35,9 @@ pub struct PendingTopPort {
 pub struct ConnectionPattern {
     pub loc: Span,
     pub kind: ConnectionPatternKind,
+    /// The source instance.
     pub source: (ComponentInstance, Span),
+    /// The target instances.
     pub targets: Vec<(ComponentInstance, Span)>,
 }
 
@@ -212,6 +214,7 @@ impl Topology {
         underlying: PortInstanceIdentifier,
         underlying_loc: Span,
     ) -> SemanticResult {
+        // Check that the topology port is for a general port
         if matches!(underlying.port_instance, PortInstance::Internal { .. }) {
             return Err(SemanticError::InvalidPortInstance {
                 loc,

--- a/fpp_analysis/src/semantics/type_spec.rs
+++ b/fpp_analysis/src/semantics/type_spec.rs
@@ -70,8 +70,9 @@ fn type_identity_does_not_hold_for_distinct_pairs() {
             (default_abs_type(), default_enum()),
             (default_array(), default_struct()),
             (boolean(), string(None)),
-            // duplicate(String(None)) -> two unsized strings are NOT identical
-            // (Scala has no String case in areIdentical).
+            // duplicate(String(None)) -> two unsized strings are NOT identical:
+            // identical() has no String arm, so they fall through to the
+            // def_node_id comparison, which strings lack.
             (string(None), string(None)),
             (f32(), f64()),
             (i8(), u32()),
@@ -96,8 +97,6 @@ fn type_identity_does_not_hold_for_distinct_pairs() {
 
 // ---------------------------------------------------------------------------
 // "type conversion" should ...
-//
-// Scala `Type.mayBeConverted((from, to))`; Rust `Type::convert(from, to).is_ok()`.
 // ---------------------------------------------------------------------------
 
 fn may_be_converted(from: &std::sync::Arc<Type>, to: &std::sync::Arc<Type>) -> bool {
@@ -238,8 +237,6 @@ fn type_conversion_disallowed_pairs() {
 
 // ---------------------------------------------------------------------------
 // "common types" should ...
-//
-// Scala `Type.commonType(t1, t2)`; Rust `Type::common_type(&t1, &t2)`.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -521,7 +518,6 @@ fn displayable_types() {
 // ---------------------------------------------------------------------------
 // "size of" should ...
 //
-// Scala `SerializedSize.ty(a, t)`; Rust `t.serialized_size(&a)`.
 // String data size default = FW_FIXED_LENGTH_STRING_SIZE = 256; the length
 // prefix type FwSizeStoreType = U16 contributes 2 bytes.
 // ---------------------------------------------------------------------------
@@ -608,7 +604,7 @@ fn size_of_structs() {
         let string_size_10 = string_with_size(10); // 12
         let string_alias = alias_type("StringAlias", string_with_size(100), 104); // 102
 
-        // struct1: m1=array1(24)*2=48, m2=F64(8)=8, m3=enumAlias(2)=2, m4=string10(12)*3=36 => 94
+        // struct1: m1=array1(24)*2=48, m2=F64(8)=8, m3=enum_alias(2)=2, m4=string10(12)*3=36 => 94
         let struct1 = struct_ty_sized(
             "S",
             anon_struct(&[
@@ -622,7 +618,7 @@ fn size_of_structs() {
         );
         assert_eq!(struct1.serialized_size(&a), Some(94));
 
-        // struct2: m1=array2(48)=48, m2=stringAlias(102)=102, m3=struct1(94)*2=188 => 338
+        // struct2: m1=array2(48)=48, m2=string_alias(102)=102, m3=struct1(94)*2=188 => 338
         let struct2 = struct_ty_sized(
             "S2",
             anon_struct(&[
@@ -660,8 +656,7 @@ fn size_of_types_with_no_size() {
 
 // ---------------------------------------------------------------------------
 // Additional coverage: `Type` predicate/helper methods (many recurse through
-// alias types). These are not part of the Scala `TypeSpec` but exercise the
-// same `Type` surface.
+// alias types), exercising the same `Type` surface.
 // ---------------------------------------------------------------------------
 
 use crate::semantics::Value;

--- a/fpp_analysis/src/semantics/types.rs
+++ b/fpp_analysis/src/semantics/types.rs
@@ -9,13 +9,18 @@ use std::fmt::{Debug, Display, Formatter};
 use std::ops::Deref;
 use std::sync::Arc;
 
+/// An FPP Type
 #[derive(Debug, Clone)]
 pub enum Type {
+    /// Primitive integer types
     PrimitiveInt(IntegerKind),
+    /// Floating-point types
     Float(FloatKind),
+    /// The type of a string
     String(Option<i128>),
+    /// The Boolean type
     Boolean,
-    /** The type of arbitrary-width integers */
+    /// The type of arbitrary-width integers
     Integer,
     AbsType(AbsType),
     AliasType(AliasType),
@@ -27,6 +32,7 @@ pub enum Type {
 }
 
 impl Type {
+    /// Get the underlying type
     pub fn underlying_type(ty: &Arc<Type>) -> Arc<Type> {
         match ty.deref() {
             Type::AliasType(alias) => Type::underlying_type(&alias.alias_type),
@@ -34,7 +40,7 @@ impl Type {
         }
     }
 
-    /** Get the default value */
+    /// Get the default value
     pub fn default_value(&self) -> Option<Value> {
         match self {
             Type::PrimitiveInt(kind) => Some(Value::PrimitiveInteger(PrimitiveIntegerValue {
@@ -69,7 +75,7 @@ impl Type {
         }
     }
 
-    /** Get the array size */
+    /// Get the array size
     pub fn array_size(&self) -> Option<usize> {
         match self {
             Type::AliasType(ty) => ty.alias_type.array_size(),
@@ -79,7 +85,7 @@ impl Type {
         }
     }
 
-    /** Get the definition node identifier, if any */
+    /// Get the definition node identifier, if any
     pub fn def_node_id(&self) -> Option<fpp_core::Node> {
         match self {
             Type::AbsType(ty) => Some(ty.node.node_id),
@@ -91,7 +97,7 @@ impl Type {
         }
     }
 
-    /** Does this type have numeric members? */
+    /// Does this type have numeric members?
     pub fn has_numeric_members(&self) -> bool {
         match self {
             Type::AliasType(ty) => ty.alias_type.has_numeric_members(),
@@ -110,7 +116,7 @@ impl Type {
         }
     }
 
-    /** Is this type convertible to a numeric type? */
+    /// Is this type convertible to a numeric type?
     pub fn is_convertible_to_numeric(&self) -> bool {
         match self {
             Type::AliasType(ty) => ty.alias_type.is_convertible_to_numeric(),
@@ -119,7 +125,7 @@ impl Type {
         }
     }
 
-    /** Is this type promotable to an array type? */
+    /// Is this type promotable to an array type?
     pub fn is_promotable_to_array(&self) -> bool {
         match self {
             Type::AliasType(ty) => ty.alias_type.is_promotable_to_array(),
@@ -130,7 +136,7 @@ impl Type {
         }
     }
 
-    /** Is this type displayable? */
+    /// Is this type displayable?
     pub fn is_displayable(&self) -> bool {
         match self {
             Type::PrimitiveInt(_) => true,
@@ -154,7 +160,7 @@ impl Type {
         }
     }
 
-    /** Is this type a float type? */
+    /// Is this type a float type?
     pub fn is_float(&self) -> bool {
         match self {
             Type::AliasType(ty) => ty.alias_type.is_float(),
@@ -244,7 +250,7 @@ impl Type {
         }
     }
 
-    /** Is this type an int type? */
+    /// Is this type an int type?
     pub fn is_int(&self) -> bool {
         match self {
             Type::AliasType(ty) => ty.alias_type.is_int(),
@@ -254,7 +260,7 @@ impl Type {
         }
     }
 
-    /** Is this type a primitive type? */
+    /// Is this type a primitive type?
     pub fn is_primitive(&self) -> bool {
         match self {
             Type::AliasType(ty) => ty.alias_type.is_primitive(),
@@ -265,17 +271,17 @@ impl Type {
         }
     }
 
-    /** Is this type a canonical (non-aliased) type? */
+    /// Is this type a canonical (non-aliased) type?
     pub fn is_canonical(&self) -> bool {
         !matches!(self, Type::AliasType(_))
     }
 
-    /** Is this type promotable to a struct type? */
+    /// Is this type promotable to a struct type?
     pub fn is_promotable_to_struct(&self) -> bool {
         self.is_promotable_to_array()
     }
 
-    /** Is this type numeric? */
+    /// Is this type numeric?
     pub fn is_numeric(&self) -> bool {
         match self {
             Type::AliasType(ty) => ty.alias_type.is_numeric(),
@@ -283,6 +289,7 @@ impl Type {
         }
     }
 
+    /// Is `from` convertible to `to`?
     pub fn convert(from: &Arc<Type>, to: &Arc<Type>) -> TypeConversionResult {
         Type::convert_impl(
             Type::underlying_type(from).deref(),
@@ -428,7 +435,7 @@ impl Type {
         }
     }
 
-    /** Check for type identity */
+    /// Check for type identity
     pub fn identical(t1: &Type, t2: &Type) -> bool {
         match (t1, t2) {
             (Type::PrimitiveInt(k1), Type::PrimitiveInt(k2)) => k1 == k2,
@@ -442,6 +449,7 @@ impl Type {
         }
     }
 
+    /// Compute the common type for a pair of types
     pub fn common_type(t1_a: &Arc<Type>, t2_a: &Arc<Type>) -> Option<Arc<Type>> {
         // Trivial case, types are the same
         if Type::identical(t1_a, t2_a) {
@@ -736,6 +744,7 @@ impl TypeConversionError {
 
 pub type TypeConversionResult = Result<(), TypeConversionError>;
 
+/// Primitive types
 pub trait PrimitiveType {
     fn bit_width(&self) -> u32;
 }
@@ -781,75 +790,75 @@ impl PrimitiveType for FloatKind {
     }
 }
 
-/** An abstract type */
+/// An abstract type
 #[derive(Debug, Clone)]
 pub struct AbsType {
-    /** The AST node giving the definition */
+    /// The AST node giving the definition
     pub node: fpp_ast::DefAbsType,
     pub default_value: Option<AbsTypeValue>,
 }
 
-/** An alias type */
+/// An alias type
 #[derive(Debug, Clone)]
 pub struct AliasType {
-    /** The AST node giving the definition */
+    /// The AST node giving the definition
     pub node: fpp_ast::DefAliasType,
-    /** Type that this typedef points to */
+    /// Type that this typedef points to
     pub alias_type: Arc<Type>,
 }
 
-/** A named array type */
+/// A named array type
 #[derive(Debug, Clone)]
 pub struct ArrayType {
-    /** The AST node giving the definition */
+    /// The AST node giving the definition
     pub node: fpp_ast::DefArray,
-    /** The structurally equivalent anonymous array */
+    /// The structurally equivalent anonymous array
     pub anon_array: AnonArrayType,
-    /** The specified default value, if any */
+    /// The specified default value, if any
     pub default: Option<Value>,
-    /** The specified format, if any */
+    /// The specified format, if any
     pub format: Option<Format>,
 }
 
-/** An anonymous array type */
+/// An anonymous array type
 #[derive(Debug, Clone)]
 pub struct AnonArrayType {
-    /** The array size */
+    /// The array size
     pub size: Option<usize>,
-    /** The element type */
+    /// The element type
     pub elt_type: Arc<Type>,
 }
 
-/** An enum type */
+/// An enum type
 #[derive(Debug, Clone)]
 pub struct EnumType {
-    /** The AST node giving the definition */
+    /// The AST node giving the definition
     pub node: fpp_ast::DefEnum,
-    /** The representation type */
+    /// The representation type
     pub rep_type: IntegerKind,
-    /** The default value */
+    /// The default value
     pub default: Option<Value>,
 }
 
-/** A named struct type */
+/// A named struct type
 #[derive(Debug, Clone)]
 pub struct StructType {
-    /** The AST node giving the definition */
+    /// The AST node giving the definition
     pub node: fpp_ast::DefStruct,
-    /** The structurally equivalent anonymous struct type */
+    /// The structurally equivalent anonymous struct type
     pub anon_struct: AnonStructType,
-    /** The default value */
+    /// The default value
     pub default: Option<StructValue>,
-    /** The member sizes */
+    /// The member sizes
     pub sizes: HashMap<String, u32>,
-    /** The member formats */
+    /// The member formats
     pub formats: HashMap<String, Format>,
 }
 
-/** An anonymous struct type */
+/// An anonymous struct type
 #[derive(Debug, Clone)]
 pub struct AnonStructType {
-    /** The members */
+    /// The members
     pub members: HashMap<String, Arc<Type>>,
 }
 

--- a/fpp_analysis/src/semantics/value.rs
+++ b/fpp_analysis/src/semantics/value.rs
@@ -6,6 +6,7 @@ use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
 
+/// An FPP value
 #[derive(Debug, Clone)]
 pub enum Value {
     PrimitiveInteger(PrimitiveIntegerValue),
@@ -34,6 +35,7 @@ impl Value {
         )
     }
 
+    /// Convert this value to a type
     pub fn convert(&self, ty_a: &Arc<Type>) -> Option<Value> {
         match (self.convert_impl(ty_a), self.is_promotable_to_aggregate()) {
             (Some(value), _) => Some(value),
@@ -85,6 +87,7 @@ impl Value {
         }
     }
 
+    /// Convert this value to a distinct type
     fn convert_impl(&self, ty_a: &Arc<Type>) -> Option<Value> {
         let ty = Type::underlying_type(ty_a);
 
@@ -216,6 +219,7 @@ impl Value {
         }
     }
 
+    /// Generic binary operation
     fn binop(
         &self,
         other: &Value,
@@ -312,6 +316,7 @@ impl Value {
         }
     }
 
+    /// Add two values
     pub fn add(&self, other: &Value) -> MathResult {
         // String concatenation
         if let (Value::String(StringValue(left)), Value::String(StringValue(right))) = (self, other)
@@ -325,6 +330,7 @@ impl Value {
         )
     }
 
+    /// Divide one value by another
     pub fn div(&self, other: &Value) -> MathResult {
         self.binop(
             other,
@@ -345,6 +351,7 @@ impl Value {
         )
     }
 
+    /// Multiply two values
     pub fn mul(&self, other: &Value) -> MathResult {
         self.binop(
             other,
@@ -353,6 +360,7 @@ impl Value {
         )
     }
 
+    /// Subtract one value from another
     pub fn sub(&self, other: &Value) -> MathResult {
         self.binop(
             other,
@@ -387,9 +395,9 @@ impl Value {
             Value::Array(ArrayValue { ty, .. }) => ty.clone(),
             Value::Struct(StructValue { ty, .. }) => ty.clone(),
             Value::AnonArray(AnonArrayValue { elements }) => {
-                // Mirrors Scala `AnonArray.getType`, which reads the element type
-                // from the first element (an anon-array value is never empty in
-                // practice, since it is built from a non-empty literal).
+                // Reads the element type from the first element (an anon-array
+                // value is never empty in practice, since it is built from a
+                // non-empty literal).
                 let elt_type = elements
                     .first()
                     .map(|e| e.get_type())
@@ -412,8 +420,9 @@ impl Value {
     }
 
     /// Whether this value is zero, for purposes of division. Floats use an
-    /// epsilon comparison (Scala `Float.EPSILON`).
+    /// epsilon comparison.
     pub fn is_zero(&self) -> bool {
+        // Epsilon for nearness to zero
         const EPSILON: f64 = 0.0000001;
         match self {
             Value::PrimitiveInteger(PrimitiveIntegerValue { value, .. })
@@ -450,13 +459,13 @@ impl Value {
     }
 
     /// Left-shifts an integer value by another. Returns `None` unless both
-    /// operands are integers or enums (Scala `<<`).
+    /// operands are integers or enums.
     pub fn shl(&self, other: &Value) -> Option<Value> {
         self.int_shift_op(other, |v, s| v << s)
     }
 
     /// Right-shifts an integer value by another. Returns `None` unless both
-    /// operands are integers or enums (Scala `>>`).
+    /// operands are integers or enums.
     pub fn shr(&self, other: &Value) -> Option<Value> {
         self.int_shift_op(other, |v, s| v >> s)
     }
@@ -534,7 +543,7 @@ impl Value {
 }
 
 /// Truncates an integer to the width and signedness of `kind`, wrapping modulo
-/// the type's range (mirrors Scala `PrimitiveInt.truncate`).
+/// the type's range.
 fn truncate_int(value: i128, kind: IntegerKind) -> i128 {
     match kind {
         IntegerKind::I8 => value as i8 as i128,
@@ -578,46 +587,46 @@ pub enum MathError {
 
 pub type MathResult = Result<Value, MathError>;
 
-/** Primitive integer values */
+/// Primitive integer values
 #[derive(Debug, Clone)]
 pub struct PrimitiveIntegerValue {
     pub value: i128,
     pub kind: fpp_ast::IntegerKind,
 }
 
-/** Integer values */
+/// Integer values
 #[derive(Debug, Clone)]
 pub struct IntegerValue(pub i128);
 
-/** Floating-point values */
+/// Floating-point values
 #[derive(Debug, Clone)]
 pub struct FloatValue {
     pub value: f64,
     pub kind: FloatKind,
 }
 
-/** Boolean values */
+/// Boolean values
 #[derive(Debug, Clone)]
 pub struct BooleanValue(pub bool);
 
-/** String values */
+/// String values
 #[derive(Debug, Clone)]
 pub struct StringValue(pub String);
 
-/** Anonymous array values */
+/// Anonymous array values
 #[derive(Debug, Clone)]
 pub struct AnonArrayValue {
     pub elements: Vec<Value>,
 }
 
-/** Array values */
+/// Array values
 #[derive(Debug, Clone)]
 pub struct ArrayValue {
     pub anon_array: AnonArrayValue,
     pub ty: Arc<Type>,
 }
 
-/** Enum constant values */
+/// Enum constant values
 #[derive(Debug, Clone)]
 pub struct EnumConstantValue {
     pub value: (String, i128),
@@ -649,17 +658,20 @@ impl EnumConstantValue {
     }
 }
 
+/// Anonymous struct values
 #[derive(Debug, Clone)]
 pub struct AnonStructValue {
     pub members: HashMap<String, Value>,
 }
 
+/// Struct values
 #[derive(Debug, Clone)]
 pub struct StructValue {
     pub anon_struct: AnonStructValue,
     pub ty: Arc<Type>,
 }
 
+/// An abstract type
 #[derive(Debug, Clone)]
 pub struct AbsTypeValue {
     pub ty: Arc<Type>,

--- a/fpp_analysis/src/semantics/value_spec.rs
+++ b/fpp_analysis/src/semantics/value_spec.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 /// Structural equality on `Value` (which does not derive `PartialEq`).
 ///
-/// Mirrors how the Scala `ValueSpec` compares values with case-class `==`.
 /// Floats use exact `f64` equality because every test uses whole/half numbers.
 fn values_eq(a: &Value, b: &Value) -> bool {
     match (a, b) {
@@ -80,8 +79,7 @@ fn members_eq(m1: &FxHashMap<String, Value>, m2: &FxHashMap<String, Value>) -> b
             .all(|(name, v1)| m2.get(name).is_some_and(|v2| values_eq(v1, v2)))
 }
 
-/// The anon-struct value `{ a = U32(0), b = String("") }`
-/// (mirrors Scala `Values.anonStruct`).
+/// The anon-struct value `{ a = U32(0), b = String("") }`.
 fn anon_struct_val() -> Value {
     let mut m: FxHashMap<String, Value> = FxHashMap::default();
     m.insert("a".to_string(), v_u32(0));
@@ -89,8 +87,7 @@ fn anon_struct_val() -> Value {
     Value::AnonStruct(AnonStructValue { members: m })
 }
 
-/// The array value `[ I32(0), I32(0), I32(0) ]: A` (mirrors Scala
-/// `Values.array = Array(defaultAnonArray3I32, Types.defaultArray)`).
+/// The array value `[ I32(0), I32(0), I32(0) ]: A`.
 fn array_val() -> Value {
     Value::Array(ArrayValue {
         anon_array: AnonArrayValue {
@@ -100,9 +97,7 @@ fn array_val() -> Value {
     })
 }
 
-/// The struct value `{ a = U32(0), b = String("") }: S` (mirrors Scala
-/// `Values.struct = Struct(anonStruct, structType)`, where
-/// `structType = struct("S", anonStructType, 3)`).
+/// The struct value `{ a = U32(0), b = String("") }: S`.
 fn struct_val() -> Value {
     let mut m: FxHashMap<String, Value> = FxHashMap::default();
     m.insert("a".to_string(), v_u32(0));
@@ -114,8 +109,7 @@ fn struct_val() -> Value {
 }
 
 /// Drives a table of `(lhs, rhs, expected)` cases through a binary op.
-/// `Some(v)` means the Scala `Some(v)` result (`Ok` with `values_eq`);
-/// `None` means the Scala `None` result (`Err`).
+/// `Some(v)` means `Ok` (checked with `values_eq`); `None` means `Err`.
 #[track_caller]
 fn check_binop(
     op_name: &str,
@@ -260,8 +254,6 @@ fn value_div() {
 
 // ---------------------------------------------------------------------------
 // "convert to type" should ...
-//
-// Scala `value.convertToType(t)`; Rust `value.convert(&t)`.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -335,8 +327,8 @@ fn value_convert_to_type() {
 }
 
 // ---------------------------------------------------------------------------
-// Additional coverage: conversion paths and `Display` not reached by the
-// direct ValueSpec port above.
+// Additional coverage: conversion paths and `Display` not otherwise
+// exercised by the cases above.
 // ---------------------------------------------------------------------------
 
 /// A scalar promotes to a *named* array/struct target, yielding a `Value::Array`
@@ -468,10 +460,9 @@ fn value_display() {
 }
 
 // ---------------------------------------------------------------------------
-// "getType" should ...
+// "get_type" should ...
 //
-// Scala `value.getType`; Rust `value.get_type()`. Compared with
-// `types_structurally_eq`.
+// Compared with `types_structurally_eq`.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -533,7 +524,6 @@ fn value_get_type() {
 // ---------------------------------------------------------------------------
 // "lshift" / "rshift" should ...
 //
-// Scala `<<` / `>>`; Rust `value.shl(&other)` / `value.shr(&other)`.
 // `Some(v)` => `Some` (compared with `values_eq`); `None` => `None`.
 // ---------------------------------------------------------------------------
 

--- a/fpp_ast/src/component.rs
+++ b/fpp_ast/src/component.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+/// Component member
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum ComponentMember {
@@ -31,7 +32,7 @@ pub enum InputPortKind {
     Sync,
 }
 
-/** Queue full behavior */
+/// Queue full behavior
 #[derive(Debug, Clone)]
 pub enum QueueFull {
     Assert,
@@ -40,6 +41,7 @@ pub enum QueueFull {
     Hook,
 }
 
+/// Command specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecCommand {
@@ -53,6 +55,7 @@ pub struct SpecCommand {
     pub queue_full: Option<QueueFull>,
 }
 
+/// Container specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecContainer {
@@ -61,6 +64,7 @@ pub struct SpecContainer {
     pub default_priority: Option<Expr>,
 }
 
+/// Event severity
 #[derive(Debug, Clone)]
 pub enum EventSeverity {
     ActivityHigh,
@@ -79,6 +83,7 @@ pub struct EventThrottle {
     pub every: Option<Expr>,
 }
 
+/// Event specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecEvent {
@@ -92,7 +97,7 @@ pub struct SpecEvent {
     pub throttle: Option<EventThrottle>,
 }
 
-/** Internal port specifier */
+/// Internal port specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecInternalPort {
@@ -103,6 +108,7 @@ pub struct SpecInternalPort {
     pub queue_full: Option<QueueFull>,
 }
 
+/// Parameter specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecParam {
@@ -116,12 +122,14 @@ pub struct SpecParam {
     pub is_external: bool,
 }
 
+/// General port instance kind
 #[derive(Debug, Clone)]
 pub enum GeneralPortInstanceKind {
     Input(InputPortKind),
     Output,
 }
 
+/// Special port instance kind
 #[derive(Debug, Clone)]
 pub enum SpecialPortInstanceKind {
     CommandRecv,
@@ -160,6 +168,7 @@ impl std::fmt::Display for SpecialPortInstanceKind {
     }
 }
 
+/// Port matching specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecPortMatching {
@@ -167,6 +176,7 @@ pub struct SpecPortMatching {
     pub port2: Ident,
 }
 
+/// Record specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecRecord {
@@ -177,6 +187,7 @@ pub struct SpecRecord {
     pub id: Option<Expr>,
 }
 
+/// State machine instance spec
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecStateMachineInstance {
@@ -187,12 +198,14 @@ pub struct SpecStateMachineInstance {
     pub queue_full: Option<QueueFull>,
 }
 
+/// Telemetry update
 #[derive(Debug, Clone)]
 pub enum TlmChannelUpdate {
     Always,
     OnChange,
 }
 
+/// Telemetry limit kind
 #[derive(Debug, Clone)]
 pub enum TlmChannelLimitKind {
     Red,
@@ -200,6 +213,7 @@ pub enum TlmChannelLimitKind {
     Yellow,
 }
 
+/// Telemetry limit
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct TlmChannelLimit {
@@ -208,6 +222,7 @@ pub struct TlmChannelLimit {
     pub value: Expr,
 }
 
+/// Telemetry channel specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecTlmChannel {

--- a/fpp_ast/src/lib.rs
+++ b/fpp_ast/src/lib.rs
@@ -19,6 +19,7 @@ pub trait AstNode: fpp_core::Spanned + Sized {
     fn id(&self) -> fpp_core::Node;
 }
 
+/// Translation unit
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct TransUnit(pub Vec<ModuleMember>);
 
@@ -42,7 +43,7 @@ pub struct LitString {
     pub inner_span: fpp_core::Span,
 }
 
-/** Definition name */
+/// Definition name
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct Name {
@@ -50,7 +51,7 @@ pub struct Name {
     pub data: String,
 }
 
-/** Identifier */
+/// Identifier
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct Ident {
@@ -58,12 +59,14 @@ pub struct Ident {
     pub data: String,
 }
 
+/// Float type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloatKind {
     F32,
     F64,
 }
 
+/// Int type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntegerKind {
     U8,
@@ -88,12 +91,14 @@ pub enum TypeNameKind {
     String(Option<Expr>),
 }
 
+/// Type name
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct TypeName {
     pub kind: TypeNameKind,
 }
 
+/// A qualified identifier
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct Qualified {
@@ -101,13 +106,16 @@ pub struct Qualified {
     pub name: Ident,
 }
 
+/// A possibly-qualified identifier
 #[ast]
 #[derive(Clone, VisitorWalkable)]
 pub enum QualIdent {
+    /// An unqualified identifier
     Unqualified(Ident),
     Qualified(Qualified),
 }
 
+/// Struct member
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct StructExprMember {
@@ -152,18 +160,21 @@ pub enum ExprKind {
     },
 }
 
+/// Expression
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct Expr {
     pub kind: ExprKind,
 }
 
+/// Formal parameter kind
 #[derive(Debug, Clone)]
 pub enum FormalParamKind {
     Ref,
     Value,
 }
 
+/// Formal parameter
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct FormalParam {
@@ -173,9 +184,10 @@ pub struct FormalParam {
     pub type_name: TypeName,
 }
 
+/// Formal parameter list
 pub type FormalParamList = Vec<FormalParam>;
 
-/** Binary operation */
+/// Binary operation
 #[derive(Debug, Clone)]
 pub enum Binop {
     Add,
@@ -186,19 +198,20 @@ pub enum Binop {
     RShift,
 }
 
+/// Unary operation
 #[derive(Debug, Clone)]
 pub enum Unop {
     Minus,
 }
 
-/** Abstract type definition */
+/// Abstract type definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefAbsType {
     pub name: Name,
 }
 
-/** Aliased type definition */
+/// Aliased type definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefAliasType {
@@ -208,7 +221,7 @@ pub struct DefAliasType {
     pub is_dictionary_def: bool,
 }
 
-/** Array definition */
+/// Array definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefArray {
@@ -222,6 +235,7 @@ pub struct DefArray {
     pub is_dictionary_def: bool,
 }
 
+/// Component kind
 #[derive(Debug, Clone)]
 pub enum ComponentKind {
     Active,
@@ -229,7 +243,7 @@ pub enum ComponentKind {
     Queued,
 }
 
-/** Component definition */
+/// Component definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefComponent {
@@ -239,7 +253,7 @@ pub struct DefComponent {
     pub members: Vec<ComponentMember>,
 }
 
-/** Component instance definition */
+/// Component instance definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefComponentInstance {
@@ -257,7 +271,7 @@ pub struct DefComponentInstance {
     pub init_specs: Vec<SpecInit>,
 }
 
-/** Init specifier */
+/// Init specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecInit {
@@ -266,7 +280,7 @@ pub struct SpecInit {
     pub code: LitString,
 }
 
-/** Constant definition */
+/// Constant definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefConstant {
@@ -276,7 +290,7 @@ pub struct DefConstant {
     pub is_dictionary_def: bool,
 }
 
-/** Enum definition */
+/// Enum definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefEnum {
@@ -288,7 +302,7 @@ pub struct DefEnum {
     pub is_dictionary_def: bool,
 }
 
-/** Enum constant definition */
+/// Enum constant definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefEnumConstant {
@@ -296,7 +310,7 @@ pub struct DefEnumConstant {
     pub value: Option<Expr>,
 }
 
-/** Module definition */
+/// Module definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefModule {
@@ -304,6 +318,7 @@ pub struct DefModule {
     pub members: Vec<ModuleMember>,
 }
 
+/// Module member
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum ModuleMember {
@@ -325,6 +340,7 @@ pub enum ModuleMember {
     SpecLoc(SpecLoc),
 }
 
+/// Location specifier kind
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SpecLocKind {
     Component,
@@ -337,7 +353,7 @@ pub enum SpecLocKind {
     Interface,
 }
 
-/** Location specifier */
+/// Location specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecLoc {
@@ -350,6 +366,7 @@ pub struct SpecLoc {
     pub is_dictionary_def: bool,
 }
 
+/// General port instance
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecGeneralPortInstance {
@@ -363,6 +380,7 @@ pub struct SpecGeneralPortInstance {
     pub queue_full: Option<QueueFull>,
 }
 
+/// Special port instance
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecSpecialPortInstance {
@@ -376,6 +394,7 @@ pub struct SpecSpecialPortInstance {
     pub queue_full: Option<QueueFull>,
 }
 
+/// Port instance specifier
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum SpecPortInstance {
@@ -383,7 +402,7 @@ pub enum SpecPortInstance {
     Special(SpecSpecialPortInstance),
 }
 
-/** Interface member */
+/// Interface member
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum InterfaceMember {
@@ -391,7 +410,7 @@ pub enum InterfaceMember {
     SpecInterfaceImport(SpecInterfaceImport),
 }
 
-/** Interface definition */
+/// Interface definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefInterface {
@@ -399,6 +418,7 @@ pub struct DefInterface {
     pub members: Vec<InterfaceMember>,
 }
 
+/// Struct type member
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct StructTypeMember {
@@ -409,7 +429,7 @@ pub struct StructTypeMember {
     pub format: Option<LitString>,
 }
 
-/** Struct definition */
+/// Struct definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefStruct {
@@ -420,6 +440,7 @@ pub struct DefStruct {
     pub is_dictionary_def: bool,
 }
 
+/// Port definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefPort {
@@ -428,7 +449,7 @@ pub struct DefPort {
     pub return_type: Option<TypeName>,
 }
 
-/** Include specifier */
+/// Include specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecInclude {
@@ -436,7 +457,7 @@ pub struct SpecInclude {
     pub file: LitString,
 }
 
-/** Import specifier */
+/// Import specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecInterfaceImport {

--- a/fpp_ast/src/state_machine.rs
+++ b/fpp_ast/src/state_machine.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+/// State machine definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefStateMachine {
@@ -7,6 +8,7 @@ pub struct DefStateMachine {
     pub members: Option<Vec<StateMachineMember>>,
 }
 
+/// State machine member
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum StateMachineMember {
@@ -25,7 +27,7 @@ pub enum StateMachineMember {
     SpecInitialTransition(SpecInitialTransition),
 }
 
-/** Action definition */
+/// Action definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefAction {
@@ -33,7 +35,7 @@ pub struct DefAction {
     pub type_name: Option<TypeName>,
 }
 
-/** Choice definition */
+/// Choice definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefChoice {
@@ -43,7 +45,7 @@ pub struct DefChoice {
     pub else_transition: TransitionExpr,
 }
 
-/** Guard definition */
+/// Guard definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefGuard {
@@ -51,7 +53,7 @@ pub struct DefGuard {
     pub type_name: Option<TypeName>,
 }
 
-/** Transition expression */
+/// Transition expression
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct TransitionExpr {
@@ -59,7 +61,7 @@ pub struct TransitionExpr {
     pub target: QualIdent,
 }
 
-/** Signal definition */
+/// Signal definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefSignal {
@@ -67,6 +69,7 @@ pub struct DefSignal {
     pub type_name: Option<TypeName>,
 }
 
+/// State definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefState {
@@ -74,6 +77,7 @@ pub struct DefState {
     pub members: Vec<StateMember>,
 }
 
+/// State member
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum StateMember {
@@ -86,28 +90,28 @@ pub enum StateMember {
     SpecStateTransition(SpecStateTransition),
 }
 
-/** Initial state specifier */
+/// Initial state specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecInitialTransition {
     pub transition: TransitionExpr,
 }
 
-/** State entry specifier */
+/// State entry specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecStateEntry {
     pub actions: DoExpr,
 }
 
-/** State exit specifier */
+/// State exit specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecStateExit {
     pub actions: DoExpr,
 }
 
-/** Transition specifier */
+/// Transition specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecStateTransition {
@@ -122,7 +126,7 @@ pub struct DoExpr {
     pub actions: Vec<Ident>,
 }
 
-/** Transition or do within transition specifier */
+/// Transition or do within transition specifier
 #[derive(Debug, Clone, DirectWalkable)]
 pub enum TransitionOrDo {
     Transition(TransitionExpr),

--- a/fpp_ast/src/topology.rs
+++ b/fpp_ast/src/topology.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-/** Topology definition */
+/// Topology definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefTopology {
@@ -11,7 +11,7 @@ pub struct DefTopology {
     pub implements: Vec<QualIdent>,
 }
 
-/** System definition */
+/// System definition
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct DefSystem {
@@ -19,6 +19,7 @@ pub struct DefSystem {
     pub topology: QualIdent,
 }
 
+/// Topology member
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum TopologyMember {
@@ -30,12 +31,14 @@ pub enum TopologyMember {
     SpecTlmPacketSet(SpecTlmPacketSet),
 }
 
+/// Component instance specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecInstance {
     pub instance: QualIdent,
 }
 
+/// Port instance identifier
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct PortInstanceIdentifier {
@@ -43,6 +46,7 @@ pub struct PortInstanceIdentifier {
     pub port_name: Ident,
 }
 
+/// Connection
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct Connection {
@@ -65,6 +69,7 @@ pub enum ConnectionPatternKind {
     Time,
 }
 
+/// Connection graph specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecDirectConnectionGraph {
@@ -72,6 +77,7 @@ pub struct SpecDirectConnectionGraph {
     pub connections: Vec<Connection>,
 }
 
+/// Connection graph specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecPatternConnectionGraph {
@@ -81,6 +87,7 @@ pub struct SpecPatternConnectionGraph {
     pub targets: Vec<QualIdent>,
 }
 
+/// Telemetry channel identifier
 #[ast]
 #[derive(Debug, Clone, VisitorWalkable)]
 pub struct TlmChannelIdentifier {
@@ -88,6 +95,7 @@ pub struct TlmChannelIdentifier {
     pub channel_name: Ident,
 }
 
+/// Topology port specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecTopPort {
@@ -95,6 +103,7 @@ pub struct SpecTopPort {
     pub underlying_port: PortInstanceIdentifier,
 }
 
+/// Telemetry packet set specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecTlmPacketSet {
@@ -103,6 +112,7 @@ pub struct SpecTlmPacketSet {
     pub omitted: Vec<TlmChannelIdentifier>,
 }
 
+/// Telemetry packet set member
 #[ast]
 #[derive(AstAnnotated, Clone, DirectWalkable)]
 pub enum TlmPacketSetMember {
@@ -110,6 +120,7 @@ pub enum TlmPacketSetMember {
     SpecTlmPacket(SpecTlmPacket),
 }
 
+/// Telemetry packet specifier
 #[ast]
 #[derive(AstAnnotated, Clone, VisitorWalkable)]
 pub struct SpecTlmPacket {
@@ -119,6 +130,7 @@ pub struct SpecTlmPacket {
     pub members: Vec<TlmPacketMember>,
 }
 
+/// Telemetry packet member
 #[ast]
 #[derive(DirectWalkable, Clone)]
 pub enum TlmPacketMember {

--- a/fpp_ast/src/visit.rs
+++ b/fpp_ast/src/visit.rs
@@ -124,6 +124,7 @@ pub trait Visitor<'ast>: Sized {
         node.walk(a, self)
     }
 
+    /// Visit a list of translation units in sequence, threading state
     fn visit_trans_units(
         &self,
         a: &mut Self::State,

--- a/fpp_core/src/interface.rs
+++ b/fpp_core/src/interface.rs
@@ -260,14 +260,14 @@ impl<E: DiagnosticEmitter> CompilerInterface for RefContainer<'_, E> {
 }
 
 pub(crate) trait CompilerInterface {
-    /** Ast Node related functions */
+    /// Ast Node related functions
     fn node_add(&self, span: &Span) -> Node;
     fn node_span(&self, node: &Node) -> Span;
     fn node_pre_annotation(&self, node: &Node) -> Vec<String>;
     fn node_post_annotation(&self, node: &Node) -> Vec<String>;
     fn node_add_annotation(&self, node: &Node, pre: Vec<String>, post: Vec<String>);
 
-    /** Source file related functions */
+    /// Source file related functions
     fn file_new(&self, uri: &str, content: String, parent: Option<SourceFile>) -> SourceFile;
     fn file_uri(&self, file: &SourceFile) -> String;
     fn file_parent(&self, file: &SourceFile) -> Option<SourceFile>;
@@ -275,7 +275,7 @@ pub(crate) trait CompilerInterface {
     fn file_lines(&self, file: &SourceFile) -> Ref<'_, LineIndex>;
     fn file_len(&self, file: &SourceFile) -> usize;
 
-    /** Span related functions */
+    /// Span related functions
     fn span_add(
         &self,
         file: SourceFile,
@@ -289,10 +289,10 @@ pub(crate) trait CompilerInterface {
     fn span_file(&self, s: &Span) -> SourceFile;
     fn span_include_span(&self, s: &Span) -> Option<Span>;
 
-    /** Diagnostic related functions */
+    /// Diagnostic related functions
     fn diagnostic_emit(&self, diag: Diagnostic);
 
-    /** Garbage collection related functions */
+    /// Garbage collection related functions
     fn garbage_collection_start(&self);
     fn garbage_collection_finish(&self) -> GarbageCollectionSet;
     fn garbage_collection_cleanup(&self, gc: &GarbageCollectionSet);

--- a/fpp_lexer/src/lexer.rs
+++ b/fpp_lexer/src/lexer.rs
@@ -23,7 +23,7 @@ pub struct Lexer<'a> {
 
 const EOF_CHAR: char = '\0';
 
-/** Verify if a character is within the number base system */
+/// Verify if a character is within the number base system
 #[inline]
 fn is_digit_in_base(ch: char, base: i32) -> bool {
     let num = match ch {


### PR DESCRIPTION
I've used AI to map and match comments from Scala FPP. This also converts the `/** */` style comments to `///` style which is Rust standard practice for doc comments